### PR TITLE
Allow relative paths in the scheduled tasks

### DIFF
--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/DataRecorder.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/DataRecorder.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import gov.nih.ncats.common.util.TimeUtil;
 import ix.core.util.KeepLastList;
 import ix.utils.Util;
+import gsrs.config.FilePathParserUtils;
 import gsrs.scheduledTasks.ScheduledTaskInitializer;
 import gsrs.scheduledTasks.SchedulerPlugin.TaskListener;
 
@@ -25,7 +26,9 @@ public class DataRecorder extends ScheduledTaskInitializer {
 
     private static final int DEFAULT_NUM_RECORDS= 10; // with default cron of very 30 sec this makes last 5 mins snapshots
    
-    private File logFile = new File("logs/dataRecorder.log");
+//    private String logFileString = new File("logs/dataRecorder.log");
+    
+    private String outputPath;
 
     private DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
 
@@ -35,19 +38,18 @@ public class DataRecorder extends ScheduledTaskInitializer {
 
     private KeepLastList<String> data= new KeepLastList<String>(DEFAULT_NUM_RECORDS);
     
-
-    @JsonProperty("outputPath")
-    public void setPath(String path) {
-        if(path !=null){
-            logFile = new File(path);
-        }
-    }
     
     @JsonProperty("dateFormat")
     public void setFormat(String format) {
         if(format !=null){
             formatter = DateTimeFormatter.ofPattern(format);
         }
+    }
+    
+
+    @JsonProperty("outputPath")
+    public void setOutputPath(String path) {
+        this.outputPath=path;
     }
     
     @JsonProperty("keep_record_count")
@@ -59,6 +61,14 @@ public class DataRecorder extends ScheduledTaskInitializer {
     
     
     
+    public File getOutputFile() {
+        return FilePathParserUtils.getFileParserBuilder()
+                           .suppliedFilePath(outputPath)
+                           .defaultFilePath("logs/dataRecorder.log")
+                           .dateFormatter(formatter)
+                           .build()
+                           .getFile();
+    }
     
     
 
@@ -80,6 +90,8 @@ public class DataRecorder extends ScheduledTaskInitializer {
             }catch(IOException e){
 
             }
+            File logFile =getOutputFile();
+            
             File tmpFile = new File(logFile.getParentFile(), logFile.getName()+".tmp");
 
             try (PrintStream out = new PrintStream(new BufferedOutputStream(new FileOutputStream(tmpFile)))) {
@@ -104,6 +116,6 @@ public class DataRecorder extends ScheduledTaskInitializer {
 
     @Override
     public String getDescription() {
-        return "Record Last X stack traces like an airplane's Flight Data Recorder" + logFile.getPath();
+        return "Record Last X stack traces like an airplane's Flight Data Recorder to :" + getOutputFile().getPath();
     }
 }

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/SQLReportScheduledTaskInitializer.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/SQLReportScheduledTaskInitializer.java
@@ -1,5 +1,6 @@
 package gsrs.module.substance.tasks;
 
+import gsrs.config.FilePathParserUtils;
 import gsrs.scheduledTasks.ScheduledTaskInitializer;
 import gsrs.springUtils.StaticContextAccessor;
 import java.io.BufferedOutputStream;
@@ -43,22 +44,19 @@ public class SQLReportScheduledTaskInitializer
 
     private Lock lock = new ReentrantLock();
 
+    
     /**
      * Returns the File used to output the report
      *
      * @return
      */
-    public File getWriteFile() {
-        if(outputPath ==null) {
-            outputPath= "reports/" + name + "-%DATE%.txt";
-        }
-        String date = formatter.format(TimeUtil.getCurrentLocalDateTime());
-        String time = formatterTime.format(TimeUtil.getCurrentLocalDateTime());
-
-        String fpath = outputPath.replace("%DATE%", date)
-                .replace("%TIME%", time);
-
-        return new File(fpath);
+    public File getOutputFile() {
+        return FilePathParserUtils.getFileParserBuilder()
+                           .suppliedFilePath(outputPath)
+                           .defaultFilePath("reports/" + name + "-%DATE%.txt")
+                           .dateFormatter(formatter)
+                           .build()
+                           .getFile();
     }
 
     private PrintStream makePrintStream(File writeFile) throws IOException {
@@ -72,7 +70,7 @@ public class SQLReportScheduledTaskInitializer
             lock.lock();
             l.message("Initializing SQL");
 
-            File writeFile = getWriteFile();
+            File writeFile = getOutputFile();
             File abfile = writeFile.getAbsoluteFile();
             File pfile = abfile.getParentFile();
             
@@ -144,7 +142,7 @@ public class SQLReportScheduledTaskInitializer
 
     @Override
     public String getDescription() {
-        return "SQL Report:" + name + ". Output to:" + getWriteFile().getPath();
+        return "SQL Report:" + name + ". Output to:" + getOutputFile().getPath();
     }
 
     public Connection getConnection() throws SQLException {


### PR DESCRIPTION
This uses a part of another PR to help deal with relative paths for exports/scheduled tasks/some logs. I think we can make other tools to find the right location for logs, etc. but this should be okay for now.