### PR TITLE
WIP: Protein and NA adjustments to views

### DIFF
--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/definitional/ProteinSubstanceDefinitionalElementImpl.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/definitional/ProteinSubstanceDefinitionalElementImpl.java
@@ -123,7 +123,6 @@ public class ProteinSubstanceDefinitionalElementImpl implements DefinitionalElem
         if(sites ==null || sites.isEmpty()){
             return;
         }
-
         consumer.accept(DefinitionalElement.of("protein.glycosylation."+letter, SiteContainer.generateShorthand(sites), 2));
 
     }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/Linkage.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/Linkage.java
@@ -53,7 +53,6 @@ public class Linkage extends GinasCommonSubData {
 		this.linkage = linkage;
 	}
 	
-    //@JsonView(BeanViews.Internal.class)
 	public String getSitesShorthand(){
 		if(siteContainer!=null){
     		return siteContainer.getShorthand();
@@ -61,36 +60,13 @@ public class Linkage extends GinasCommonSubData {
     	return "";
 	}
 
-/*
-	public void setFromMap(Map m) {
-		super.setFromMap(m);
-		linkage = (java.lang.String) (m.get("linkage"));
-		sites = toDataHolderList(
-				(List<Map>) m.get("sites"),
-				new DataHolderFactory<gov.nih.ncats.informatics.ginas.shared.model.v1.NASite>() {
-					@Override
-					public gov.nih.ncats.informatics.ginas.shared.model.v1.NASite make() {
-						return new gov.nih.ncats.informatics.ginas.shared.model.v1.NASite();
-					}
-				});
-	}
-
 	@Override
-	public Map addAttributes(Map m) {
-		super.addAttributes(m);
-
-		m.put("linkage", linkage);
-		m.put("sites", toMapList(sites));
-		return m;
-	}*/
-
-		@Override
-		@JsonIgnore
-		public List<GinasAccessReferenceControlled> getAllChildrenCapableOfHavingReferences() {
-			List<GinasAccessReferenceControlled> temp = new ArrayList<GinasAccessReferenceControlled>();
-			if(siteContainer!=null){
-				temp.addAll(siteContainer.getAllChildrenAndSelfCapableOfHavingReferences());
-			}
-			return temp;
-		}
+	@JsonIgnore
+	public List<GinasAccessReferenceControlled> getAllChildrenCapableOfHavingReferences() {
+	    List<GinasAccessReferenceControlled> temp = new ArrayList<GinasAccessReferenceControlled>();
+	    if(siteContainer!=null){
+	        temp.addAll(siteContainer.getAllChildrenAndSelfCapableOfHavingReferences());
+	    }
+	    return temp;
+	}
 }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/NucleicAcidSubstance.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/NucleicAcidSubstance.java
@@ -1,6 +1,9 @@
 package ix.ginas.models.v1;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonView;
+
+import ix.core.models.BeanViews;
 import ix.ginas.models.GinasAccessReferenceControlled;
 import ix.ginas.models.GinasSubstanceDefinitionAccess;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +18,7 @@ import java.util.*;
 //@JSONEntity(name = "nucleicAcidSubstance", title = "Nucleic Acid Substance")
 public class NucleicAcidSubstance extends Substance implements GinasSubstanceDefinitionAccess{
 	@OneToOne(cascade= CascadeType.ALL)
+	@JsonView(BeanViews.Full.class) //TODO: really need to show an underscore link
 	public NucleicAcid nucleicAcid;
 
 	
@@ -25,49 +29,18 @@ public class NucleicAcidSubstance extends Substance implements GinasSubstanceDef
 	
 	@Override
     public Modifications getModifications(){
-		if(this.nucleicAcid ==null){
-			return null;
-		}
-    	return this.nucleicAcid.getModifications();
+		return this.modifications;
     }
     
 	
-	
-    
-    @Transient
-    private boolean _dirtyModifications=false;
-    
     
     public void setModifications(Modifications m){
-    	if(this.nucleicAcid==null){
-    		this.nucleicAcid = new NucleicAcid();
-    		_dirtyModifications=true;
-    	}
-    	this.nucleicAcid.setModifications(m);
     	this.modifications=m;
     }
     
     public void setNucleicAcid(NucleicAcid p){
     	this.nucleicAcid=p;
-    	if(_dirtyModifications){
-    		this.nucleicAcid.setModifications(this.modifications);
-    		_dirtyModifications=false;
-    	}
     }
-
-	//TODO katzelda Feb 2021: delete handled in controller
-//    @Override
-//    public void delete(){
-//    	Modifications old=this.modifications;
-//    	this.modifications=null;
-//    	super.delete();
-//    	for(Subunit su:this.nucleicAcid.subunits){
-//    		su.delete();
-//    	}
-//    	if(old!=null){
-//    		old.delete();
-//    	}
-//    }
     
     public int getTotalSites(boolean includeEnds){
     	int tot=0;
@@ -127,92 +100,4 @@ public class NucleicAcidSubstance extends Substance implements GinasSubstanceDef
 		return temp;
 	}
 
-//	@Override
-//	protected void additionalDefinitionalElements(Consumer<DefinitionalElement> consumer) {
-//		if(nucleicAcid ==null || nucleicAcid.subunits ==null){
-//			return;
-//		}
-//		/*for(Subunit s : this.nucleicAcid.subunits){
-//			if(s !=null && s.sequence !=null){
-//				NucleotideSequence seq = NucleotideSequence.of(Nucleotide.cleanSequence(s.sequence));
-//				UUID uuid = s.getOrGenerateUUID();
-//				consumer.accept(DefinitionalElement.of("subunitIndex."+ uuid, s.subunitIndex==null? null: Integer.toString(s.subunitIndex)));
-//				consumer.accept(DefinitionalElement.of("subunitSeq."+ uuid , seq.toString()));
-//				consumer.accept(DefinitionalElement.of("subunitSeqLength."+ uuid , Long.toString(seq.getLength())));
-//
-//			}
-//		}*/
-//		performAddition(this.nucleicAcid, consumer, Collections.newSetFromMap(new IdentityHashMap<>()));
-//	}
-//
-//	private void performAddition(NucleicAcid nucleicAcid, Consumer<DefinitionalElement> consumer, Set<NucleicAcid> visited)
-//	{
-//		log.debug("performAddition of nucleic acid substance");
-//		if (nucleicAcid != null )
-//		{
-//			visited.add(nucleicAcid);
-//			log.debug("main part");
-//			List<DefinitionalElement>	definitionalElements = additionalElementsFor();
-//			for(DefinitionalElement de : definitionalElements)
-//			{
-//				log.debug("adding DE with key " + de.getKey() + " to consumer for a NA");
-//				consumer.accept(de);
-//			}
-//			log.debug("DE processing complete");
-//		}
-//	}
-//
-//	public List<DefinitionalElement> additionalElementsFor() {
-//		List<DefinitionalElement> definitionalElements = new ArrayList<>();
-//
-//		if(this.nucleicAcid !=null) {
-//			//this can happen be null for incomplete? so we should check it
-//
-//			if(this.nucleicAcid.subunits !=null) {
-//				for (int i = 0; i < this.nucleicAcid.subunits.size(); i++) {
-//					Subunit s = this.nucleicAcid.subunits.get(i);
-//					log.debug("processing subunit with sequence " + s.sequence);
-//					DefinitionalElement sequenceHash = DefinitionalElement.of("nucleicAcid.subunits.sequence", s.sequence, 1);
-//					definitionalElements.add(sequenceHash);
-//				}
-//			}
-//
-//			if(this.nucleicAcid.linkages !=null) {
-//				for (int i = 0; i < this.nucleicAcid.linkages.size(); i++) {
-//					Linkage l = this.nucleicAcid.linkages.get(i);
-//					log.debug("processing linkage " + l.getLinkage());
-//					DefinitionalElement linkageHash = DefinitionalElement.of("nucleicAcid.linkages.linkage", l.getLinkage(), 2);
-//					definitionalElements.add(linkageHash);
-//
-//					//check if siteContainer is null
-//					if(l.siteContainer!=null) {
-//						log.debug("processing l.siteContainer.sitesShortHand " + l.siteContainer.sitesShortHand);
-//						DefinitionalElement siteElement = DefinitionalElement.of("nucleicAcid.linkages.site", l.siteContainer.sitesShortHand, 2);
-//						definitionalElements.add(siteElement);
-//					}
-//				}
-//
-//			}
-//			if(this.nucleicAcid.sugars !=null) {
-//				for (int i = 0; i < this.nucleicAcid.sugars.size(); i++) {
-//					Sugar s = this.nucleicAcid.sugars.get(i);
-//					log.debug("processing sugar " + s.sugar);
-//					DefinitionalElement sugarElement = DefinitionalElement.of("nucleicAcid.sugars.sugar", s.sugar, 2);
-//					definitionalElements.add(sugarElement);
-//					//check if siteContainer is null
-//					if(s.siteContainer!=null) {
-//						log.debug("processing s.siteContainer.sitesShortHand " + s.siteContainer.sitesShortHand);
-//						DefinitionalElement siteElement = DefinitionalElement.of("nucleicAcid.sugars.site", s.siteContainer.sitesShortHand, 2);
-//						definitionalElements.add(siteElement);
-//					}
-//				}
-//			}
-//		}
-//
-//		if( this.modifications != null ){
-//			definitionalElements.addAll(this.modifications.getDefinitionalElements().getElements());
-//		}
-//
-//		return definitionalElements;
-//	}
 }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/ProteinSubstance.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/ProteinSubstance.java
@@ -20,7 +20,6 @@ import java.util.function.Supplier;
 @DiscriminatorValue("PRO")
 @Slf4j
 public class ProteinSubstance extends Substance implements GinasSubstanceDefinitionAccess {
-
 	@OneToOne(cascade= CascadeType.ALL)
     public Protein protein;
 
@@ -37,17 +36,6 @@ public class ProteinSubstance extends Substance implements GinasSubstanceDefinit
     	}
 		return false;
     }
-    @Override
-    public int getModificationCount(){
-    	int ret=0;
-    	if(this.modifications!=null){
-    		ret+=this.modifications.agentModifications.size();
-    		ret+=this.modifications.physicalModifications.size();
-    		ret+=this.modifications.structuralModifications.size();
-    	}
-    	return ret;
-    }
-    
     
     @Override
     public Modifications getModifications(){
@@ -80,17 +68,7 @@ public class ProteinSubstance extends Substance implements GinasSubstanceDefinit
 				_dirtyModifications=false;
 			}
 		}
-
     }
-    //TODO katzelda FEb 2021: delete handled by controller
-//    @Override
-//    public void delete(){
-//    	super.delete();
-//    	for(Subunit su:this.protein.subunits){
-//    		su.delete();
-//    	}
-//    	//protein.delete();
-//    }
 
 	@JsonIgnore
 	public GinasAccessReferenceControlled getDefinitionElement(){
@@ -107,80 +85,6 @@ public class ProteinSubstance extends Substance implements GinasSubstanceDefinit
 		return temp;
 	}
 
-
-//	@Override
-//	protected void additionalDefinitionalElements(Consumer<DefinitionalElement> consumer) {
-//		if(protein ==null || protein.subunits ==null){
-//			return;
-//		}
-//		log.trace("Starting in additionalDefinitionalElements for protein" );
-//		try	{
-//			this.copy()
-//						.canonicalize()
-//						.addDefinitionalElements(consumer);
-//		}
-//		catch(JsonProcessingException ex){
-//			log.error("error during definitional hash processing: " + ex.getMessage());
-//			ex.printStackTrace();
-//		}
-//	}
-//
-//	private void addDefinitionalElements(Consumer<DefinitionalElement> consumer) {
-//		log.trace("starting in ProteinSubstance.addDefinitionalElements");
-//		for(Subunit s : this.protein.subunits){
-//			if(s !=null && s.sequence !=null){
-//				ProteinSequence seq = ProteinSequence.of(AminoAcid.cleanSequence(s.sequence));
-//				UUID uuid = s.getOrGenerateUUID();
-//				consumer.accept(DefinitionalElement.of("subunitIndex.", s.subunitIndex==null? null: Integer.toString(s.subunitIndex), 1));
-//				consumer.accept(DefinitionalElement.of("subunitSeq.", seq.toString(), 1));
-//				consumer.accept(DefinitionalElement.of("subunitSeqLength.", Long.toString(seq.getLength()), 1));
-//
-//			}
-//		}
-//
-//		Glycosylation glycosylation = this.protein.glycosylation;
-//		if(glycosylation !=null){
-//			handleGlycosylationSites(glycosylation.getNGlycosylationSites(), "N", consumer);
-//			handleGlycosylationSites(glycosylation.getOGlycosylationSites(), "O", consumer);
-//			handleGlycosylationSites(glycosylation.getCGlycosylationSites(), "C", consumer);
-//			if(glycosylation.glycosylationType !=null){
-//				consumer.accept(DefinitionalElement.of("protein.glycosylation.type", glycosylation.glycosylationType, 2));
-//			}
-//		}
-//		List<DisulfideLink> disulfideLinks = this.protein.getDisulfideLinks();
-//		if(disulfideLinks !=null){
-//			for(DisulfideLink disulfideLink : disulfideLinks){
-//				if(disulfideLink !=null) {
-//					consumer.accept(DefinitionalElement.of("protein.disulfide", disulfideLink.getSitesShorthand(), 2));
-//				}
-//			}
-//		}
-//
-//		List<OtherLinks> otherLinks = this.protein.otherLinks;
-//		if(otherLinks !=null){
-//			for(OtherLinks otherLink : otherLinks){
-//				if(otherLink ==null){
-//					continue;
-//				}
-//				List<Site> sites = otherLink.getSites();
-//				if(sites !=null) {
-//					String shortHand = SiteContainer.generateShorthand(sites);
-//					consumer.accept(DefinitionalElement.of("protein."+shortHand, shortHand, 2));
-//					String type = otherLink.linkageType;
-//					if(type !=null){
-//						consumer.accept(DefinitionalElement.of("protein."+shortHand +".linkageType", type, 2));
-//					}
-//				}
-//			}
-//		}
-//
-//		if (this.modifications != null) {
-//			for(DefinitionalElement element : this.modifications.getDefinitionalElements().getElements()) {
-//				consumer.accept(element);
-//			}
-//		}
-//	}
-//
 	public ProteinSubstance copy() throws JsonProcessingException {
 		log.trace("in ProteinSubstance.copy method");
 			return EntityUtils.EntityWrapper.of(this).getClone();
@@ -284,15 +188,6 @@ public class ProteinSubstance extends Substance implements GinasSubstanceDefinit
 			}
 		}
 		return this;
-	}
-
-	private void handleGlycosylationSites(List<Site> sites, String letter, Consumer<DefinitionalElement> consumer){
-		if(sites ==null || sites.isEmpty()){
-			return;
-		}
-
-		consumer.accept(DefinitionalElement.of("protein.glycosylation."+letter, SiteContainer.generateShorthand(sites), 2));
-
 	}
 
 	private List<Site> translateSites(List<Site> startingSites, Map<Integer, Integer> subunitChanges) {

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/StructuralModification.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/StructuralModification.java
@@ -34,6 +34,8 @@ public class StructuralModification extends GinasCommonSubData {
     @JsonIgnore
 	@OneToOne(cascade= CascadeType.ALL)
     SiteContainer siteContainer;
+    
+    
     public List<Site> getSites(){
     	if(siteContainer!=null){
     		return siteContainer.getSites();

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/Sugar.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/Sugar.java
@@ -39,17 +39,18 @@ public class Sugar extends GinasCommonSubData {
     }
     
     
- 	public String getSitesShorthand(){
- 		if(siteContainer!=null){
-     		return siteContainer.getShorthand();
-     	}
-     	return "";
- 	}
     public void setSitesShorthand(String sites){
     	if(siteContainer==null){
     		siteContainer=new SiteContainer(this.getClass().getName());
     	}
     	siteContainer.setShorthand(sites);
+    }
+
+    public String getSitesShorthand(){
+        if(siteContainer!=null){
+            return siteContainer.getShorthand();
+        }
+        return "";
     }
 
     @Indexable
@@ -60,41 +61,18 @@ public class Sugar extends GinasCommonSubData {
 	public void setSugar(String sugar) {
 		this.sugar = sugar;
 	}
-	
-	
 
-	/*public void setFromMap(Map m) {
-		super.setFromMap(m);
-		sites = toDataHolderList(
-				(List<Map>) m.get("sites"),
-				new DataHolderFactory<gov.nih.ncats.informatics.ginas.shared.model.v1.NASite>() {
-					@Override
-					public gov.nih.ncats.informatics.ginas.shared.model.v1.NASite make() {
-						return new gov.nih.ncats.informatics.ginas.shared.model.v1.NASite();
-					}
-				});
-		sugar = (java.lang.String) (m.get("sugar"));
-	}
+
 
 	@Override
-	public Map addAttributes(Map m) {
-		super.addAttributes(m);
+	@JsonIgnore
+	public List<GinasAccessReferenceControlled> getAllChildrenCapableOfHavingReferences() {
+	    List<GinasAccessReferenceControlled> temp = new ArrayList<GinasAccessReferenceControlled>();
 
-		m.put("sites", toMapList(sites));
-		m.put("sugar", sugar);
-		return m;
-	}*/
-
-
-	  @Override
-	   	@JsonIgnore
-	   	public List<GinasAccessReferenceControlled> getAllChildrenCapableOfHavingReferences() {
-	   		List<GinasAccessReferenceControlled> temp = new ArrayList<GinasAccessReferenceControlled>();
-
-	   		if(this.siteContainer!=null){
-	   			temp.addAll(siteContainer.getAllChildrenAndSelfCapableOfHavingReferences());
-	   		}
-	   		return temp;
-	   	}
+	    if(this.siteContainer!=null){
+	        temp.addAll(siteContainer.getAllChildrenAndSelfCapableOfHavingReferences());
+	    }
+	    return temp;
+	}
 
 }


### PR DESCRIPTION
This is a WIP not yet to be merged. It will attempt to fix a few things:

1. The modification model location is inconsistent between NAs and proteins for legacy reasons. This branch deletes some fields and setters. This needs to be evaluated a lot more.
2. The protein and NA objects are set to not be shown on the simple JSON view
3. The Linkages and Sugars sites are set not to be shown on simple JSON view
4. Eventually this branch will hope to make showing only the site shorthand for NA sugar and linkages sites the default.
5. To support #4 this will need to have some config settings and ways to show the full sites if prompted, it will also need clear rules on which form to primarily trust on updates/creates.