### PR TITLE
Async indexer test fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
   - ./mvnw clean install -DskipTests
 # this is really dirty but there is so much output from these tests and turning off logging and sql isn't enough
 # so I grep for ERROR lines which will show the test failures but that returns exit code of 0 if it finds a match so we want "not" that to fail the build if there are errors
-  - ./mvnw -q test 2>/dev/null
+  - ./mvnw -q test

--- a/gsrs-module-substance-example/src/main/java/example/AsyncForNotTestConfiguration.java
+++ b/gsrs-module-substance-example/src/main/java/example/AsyncForNotTestConfiguration.java
@@ -1,0 +1,14 @@
+package example;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+/**
+ * Only EnableAsync if we aren't in tests.  For the Substance-Example which can be run as an example
+ * Substance module we want EnableAsync on, but for unit tests
+ * we don't and we run most of the substance tests from this module.
+ */
+@EnableAsync
+@Profile("!test")
+public class AsyncForNotTestConfiguration {
+}

--- a/gsrs-module-substance-example/src/main/java/example/GsrsModuleSubstanceApplication.java
+++ b/gsrs-module-substance-example/src/main/java/example/GsrsModuleSubstanceApplication.java
@@ -1,20 +1,12 @@
 package example;
 
 import gsrs.*;
-import gsrs.EnableGsrsLegacyStructureSearch;
 import gsrs.cv.EnableControlledVocabulary;
 import gsrs.module.substance.indexers.DeprecatedIndexValueMaker;
-import org.apache.catalina.connector.Connector;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
-import org.springframework.boot.web.server.WebServerFactoryCustomizer;
-import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
@@ -35,7 +27,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 //@EnableJpaRepositories(basePackages ={"ix","gsrs", "gov.nih.ncats"} )
 @EnableGsrsScheduler
 @EnableGsrsBackup
-@EnableAsync
 @EnableControlledVocabulary
 public class GsrsModuleSubstanceApplication {
 

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/RelationshipService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/RelationshipService.java
@@ -323,7 +323,11 @@ public class RelationshipService {
                     ,
                     s -> {
                         Substance newSub = (Substance) s;
-                        Relationship obj = relationshipRepository.findById(event.getRelationshipIdToInvert()).get();
+                        Optional<Relationship> byId = relationshipRepository.findById(event.getRelationshipIdToInvert());
+                        if(!byId.isPresent()){
+                            return Optional.empty();
+                        }
+                        Relationship obj = byId.get();
                         if(!obj.isAutomaticInvertible()){
                             return Optional.empty();
                         }                    

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/ChemicalSubstance.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/ChemicalSubstance.java
@@ -57,7 +57,6 @@ public class ChemicalSubstance extends Substance implements GinasSubstanceDefini
         this.moieties = new ArrayList<>(Objects.requireNonNull(moieties));
         moieties.forEach(m-> Objects.requireNonNull(m).setOwner(this));
 
-        this.setIsDirty("moieties");
     }
 
     public void addMoiety(Moiety m){


### PR DESCRIPTION
he substance-example which is used to run the tests had @EnableAsync so I removed it and put it in a separate configuration class that isn't used for tests so the tests are synchronous