### PR TITLE
Fasta support

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/sequenceSearch/SearchUsingFastaFileTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/sequenceSearch/SearchUsingFastaFileTest.java
@@ -1,0 +1,96 @@
+package example.sequenceSearch;
+
+import example.GsrsModuleSubstanceApplication;
+import gov.nih.ncats.common.sneak.Sneak;
+import gsrs.service.PayloadService;
+import gsrs.substances.tests.AbstractSubstanceJpaFullStackEntityTest;
+import ix.ginas.modelBuilders.AbstractSubstanceBuilder;
+import ix.ginas.modelBuilders.NucleicAcidSubstanceBuilder;
+import ix.ginas.modelBuilders.ProteinSubstanceBuilder;
+import ix.ginas.models.v1.Reference;
+import ix.seqaln.SequenceIndexer;
+import ix.seqaln.service.SequenceIndexerService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = {GsrsModuleSubstanceApplication.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class SearchUsingFastaFileTest extends AbstractSubstanceJpaFullStackEntityTest {
+
+    @Autowired
+    private SequenceIndexerService sut;
+
+    @Autowired
+    private PayloadService payloadService;
+
+
+    @Test
+    @WithMockUser(username = "admin", roles = "Admin")
+    public void indexNucleicAcidFastaFilePayloadAsReference() throws IOException {
+
+        testSequenceFileIsSearchable("ACGTACGTACGT", true);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "Admin")
+    public void indexProteinFastaFilePayloadAsReference() throws IOException {
+
+        testSequenceFileIsSearchable("VHLTPEEK", false);
+    }
+
+    private void testSequenceFileIsSearchable(String sequence, boolean nucleicAcid) {
+        UUID uuid = UUID.randomUUID();
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        UUID payloadId = transactionTemplate.execute(s -> {
+            try {
+                return payloadService.createPayload("myFile.fasta", "txt",
+                        ">seq1\n" +
+                                sequence,
+                        PayloadService.PayloadPersistType.PERM
+                ).id;
+            } catch (Throwable t) {
+                return Sneak.sneakyThrow(t);
+            }
+        });
+        transactionTemplate.executeWithoutResult(ignored ->{
+            try{
+        Reference ref = new Reference();
+
+        ref.addTag("fasta");
+
+        ref.uploadedFile = "http://localhost/api/v1/payload("+payloadId +")";
+        AbstractSubstanceBuilder<?,?> builder = nucleicAcid ? new NucleicAcidSubstanceBuilder() : new ProteinSubstanceBuilder();
+
+                    builder
+                    .setUUID(uuid)
+                    .addName("mySubstance")
+                    .addReference(ref)
+                    .buildJsonAnd(this::assertCreatedAPI);
+
+        }catch (Throwable e){
+            Sneak.sneakyThrow(e);
+        }
+            });
+        transactionTemplate.executeWithoutResult( ignore -> {
+            SequenceIndexer.ResultEnumeration results = sut.search(sequence, 1.0, SequenceIndexer.CutoffType.GLOBAL, nucleicAcid ?"nucleicacid": "protein");
+
+            assertTrue(results.hasMoreElements());
+            SequenceIndexer.Result result = results.nextElement();
+            assertEquals(">" + uuid + "|myFile.fasta|seq1", result.id);
+            assertEquals(1.0, result.alignments.get(0).iden);
+            assertEquals(sequence, result.alignments.get(0).query);
+            assertFalse(results.hasMoreElements());
+        });
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/SubstanceCoreConfiguration.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/SubstanceCoreConfiguration.java
@@ -8,10 +8,7 @@ import gsrs.module.substance.exporters.SubstanceSpreadsheetExporterConfiguration
 import gsrs.module.substance.hierarchy.SubstanceHierarchyFinder;
 import gsrs.module.substance.hierarchy.SubstanceHierarchyFinderConfig;
 import gsrs.module.substance.processors.RelationEventListener;
-import gsrs.module.substance.services.ConfigBasedDefinitionalElementConfiguration;
-import gsrs.module.substance.services.ConfigBasedDefinitionalElementFactory;
-import gsrs.module.substance.services.StructureResolverService;
-import gsrs.module.substance.services.StructureResolverServiceConfiguration;
+import gsrs.module.substance.services.*;
 import gsrs.module.substance.standardizer.StructureStandardizerConfiguration;
 import gsrs.module.substance.utils.MolWeightCalculatorProperties;
 import ix.ginas.utils.validation.ChemicalDuplicateFinder;
@@ -35,7 +32,7 @@ import org.springframework.context.annotation.Import;
         SubstanceHierarchyFinder.class, SubstanceHierarchyFinderConfig.class,
         ApprovalIdConfiguration.class,RendererOptionsConfig.class, MolWeightCalculatorProperties.class,
 
-
+        SubstanceSequenceFileSupportService.class
 })
 public class SubstanceCoreConfiguration {
 

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/LegacySubstanceSequenceSearchService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/LegacySubstanceSequenceSearchService.java
@@ -5,9 +5,7 @@ import gsrs.cache.GsrsCache;
 import gsrs.module.substance.repository.NucleicAcidSubstanceRepository;
 import gsrs.module.substance.repository.ProteinSubstanceRepository;
 import gsrs.module.substance.repository.SubunitRepository;
-import gsrs.service.PayloadService;
 import gsrs.springUtils.AutowireHelper;
-import ix.core.search.ResultProcessor;
 import ix.core.search.SearchResultContext;
 import ix.core.search.SearchResultProcessor;
 import ix.core.util.EntityUtils;
@@ -15,7 +13,6 @@ import ix.ginas.models.v1.Substance;
 import ix.ginas.models.v1.Subunit;
 import ix.seqaln.SequenceIndexer;
 import ix.seqaln.service.SequenceIndexerService;
-import ix.utils.CallableUtil;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.jcvi.jillion.core.Range;
@@ -26,6 +23,15 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+/**
+ * {@link SubstanceSequenceSearchService}
+ * implementation that performs sequence search like
+ * the legacy GSRS 2.x code did using a lucene
+ * index and home grown pair wise alignment code.
+ *
+ * This should eventually be replaced with something like BLAST.
+ */
 @Slf4j
 public class LegacySubstanceSequenceSearchService implements SubstanceSequenceSearchService{
     /**
@@ -33,15 +39,11 @@ public class LegacySubstanceSequenceSearchService implements SubstanceSequenceSe
      * In order to link the match context back to the substance so the alignment
      * is displayed in search results we need this regex to pull out the substance uuid.
      */
-    private static Pattern FASTA_FILE_PATTERN = Pattern.compile(">(.+)\\|(.+)");
+    private static Pattern FASTA_FILE_PATTERN = Pattern.compile(">(.+?)\\|(.+?)\\|(.+)");
 
     private SequenceIndexerService indexerService;
 
-    private ProteinSubstanceRepository proteinSubstanceRepository;
-    private NucleicAcidSubstanceRepository nucleicAcidSubstanceRepository;
-    private SubunitRepository subunitRepository;
     private GsrsCache ixCache;
-    private PayloadService payloadService;
 
 
     private SubunitRepositoryWrapper proteinAdapter;
@@ -49,18 +51,12 @@ public class LegacySubstanceSequenceSearchService implements SubstanceSequenceSe
     
 
     public LegacySubstanceSequenceSearchService(SequenceIndexerService indexerService, GsrsCache ixCache,
-                                                PayloadService payloadService,
                                                 ProteinSubstanceRepository proteinSubstanceRepository,
                                                 NucleicAcidSubstanceRepository nucleicAcidSubstanceRepository,
                                                 SubunitRepository subunitRepository
                                                 ) {
         this.indexerService = indexerService;
         this.ixCache = ixCache;
-        this.proteinSubstanceRepository = proteinSubstanceRepository;
-        this.nucleicAcidSubstanceRepository = nucleicAcidSubstanceRepository;
-        this.subunitRepository=subunitRepository;
-        
-        this.payloadService = payloadService;
         
         this.proteinAdapter = SubunitRepositoryWrapper.fromProtein(proteinSubstanceRepository, subunitRepository);
         this.naAdapter = SubunitRepositoryWrapper.fromNA(nucleicAcidSubstanceRepository, subunitRepository);
@@ -98,34 +94,12 @@ public class LegacySubstanceSequenceSearchService implements SubstanceSequenceSe
             throw new IOException("error performing search ", e);
         }
     }
-    public interface SearcherTask{
-        public String getKey();
-        public void search(ResultProcessor processor) throws Exception;
-        public long getLastUpdatedTime();
-    }
-    //TODO add this back
-
-//    public static abstract class SequenceSeachTask implements SearcherTask{
-//
-//        @Override
-//        public String getKey() {
-//            return App.getKeyForCurrentRequest();
-//        }
-//
-//        @Override
-//        public long getLastUpdatedTime() {
-//            return EntityPersistAdapter
-//                    .getSequenceIndexer()
-//                    .lastModified();
-//        }
-//
-//    }
 
     
     private interface SubunitRepositoryWrapper {
-        public Optional<Substance> getSubstanceFromSubunitUUID(UUID uuid);
-        public Optional<Subunit> getSubunitFromSubunitUUID(UUID uuid);
-        public Optional<Substance> getSubstanceByID(UUID uuid);
+        Optional<Substance> getSubstanceFromSubunitUUID(UUID uuid);
+        Optional<Subunit> getSubunitFromSubunitUUID(UUID uuid);
+        Optional<Substance> getSubstanceByID(UUID uuid);
         default Optional<Tuple<Substance,Subunit>> getSubstanceAndSubunitFromSubunitUUID(UUID uuid){
             return this.getSubunitFromSubunitUUID(uuid)
                         .map(su->Tuple.of(getSubstanceFromSubunitUUID(uuid),su))
@@ -133,13 +107,13 @@ public class LegacySubstanceSequenceSearchService implements SubstanceSequenceSe
                         .map(Tuple.kmap(op->op.get()));            
         }
         
-        public static SubunitRepositoryWrapper fromNA(NucleicAcidSubstanceRepository nucleicAcidSubstanceRepository, SubunitRepository subunitRepository) {
+        static SubunitRepositoryWrapper fromNA(NucleicAcidSubstanceRepository nucleicAcidSubstanceRepository, SubunitRepository subunitRepository) {
             return NucleicAcidSubunitRepositoryWrapper.builder()
             .nucleicAcidSubstanceRepository(nucleicAcidSubstanceRepository)
             .subunitRepository(subunitRepository)
             .build();
         }
-        public static SubunitRepositoryWrapper fromProtein(ProteinSubstanceRepository proteinSubstanceRepository, SubunitRepository subunitRepository) {
+        static SubunitRepositoryWrapper fromProtein(ProteinSubstanceRepository proteinSubstanceRepository, SubunitRepository subunitRepository) {
             return ProteinSubunitRepositoryWrapper.builder()
             .proteinSubstanceRepository(proteinSubstanceRepository)
             .subunitRepository(subunitRepository)
@@ -201,22 +175,7 @@ public class LegacySubstanceSequenceSearchService implements SubstanceSequenceSe
         
     }
     
-    private SearchResultContext search(SearcherTask task, ResultProcessor processor) {
-        try {
-            final String key = task.getKey();
-            return ixCache.getOrElse(task.getLastUpdatedTime(), key,
-                    CallableUtil.TypedCallable.of(() -> {
-                        task.search(processor);
-                        SearchResultContext ctx = processor.getContext();
-                        ctx.setKey(key);
-                        return ctx;
-                    },SearchResultContext.class));
-        }catch (Exception ex) {
-            ex.printStackTrace();
-            log.error("Can't perform advanced search", ex);
-            throw new IllegalStateException("Can't perform advanced search", ex);
-        }
-    }
+
 
     public static class GinasSequenceResultProcessor
             extends SearchResultProcessor<SequenceIndexer.Result, Substance> {
@@ -233,19 +192,22 @@ public class LegacySubstanceSequenceSearchService implements SubstanceSequenceSe
         protected Substance instrument(SequenceIndexer.Result r) throws Exception {
 
 
-            //I don't understand the logic here ...
-            //I don't think this does what it's supposed to.
-            //katzelda - needed for large fasta sequences
-            //but need tests to confirm
+
+            //katzelda - needed for large fasta sequences uploaded as references the indexer saves id
+            //in format ">substanceID | file ID | record ID
             if(r.id.startsWith(">")){
                 Matcher m = FASTA_FILE_PATTERN.matcher(r.id);
                 if(m.find()){
                     String parentId = m.group(1);
-                    String recordId = m.group(2);
+                    String fileName = m.group(2);
+                    String recordId = m.group(3);
                     Substance s= subunitRepoWrapper.getSubstanceByID(UUID.fromString(parentId)).orElse(null);
+                    //right now the result id is ">substanceID | file ID | record ID
+                    //we need that to know what the sequence is but we don't want to show that to the user
+                    //just say we have a match in that file name?
 
-                    addAlignmentToSubstanceMatchContext(r, s, (begin, end, coordinateSystem)->{
-                        return recordId+"_"+begin + "-" +recordId+"_"+end;
+                    addAlignmentToSubstanceMatchContext(r.copyWithNewId(fileName), s, (begin, end, coordinateSystem)->{
+                        return recordId+": "+begin + ".." +end;
                     });
                     return s;
                 }
@@ -292,7 +254,7 @@ public class LegacySubstanceSequenceSearchService implements SubstanceSequenceSe
                  String shorthand = Ranges.asRanges(a.targetSites())
                          .stream()
                          .map(range-> range.toString(function, Range.CoordinateSystem.RESIDUE_BASED))
-                         .collect(Collectors.joining(";","Target Sites: ","\n\n"));
+                         .collect(Collectors.joining("; ","Target Sites: ","\n\n"));
                  //this check is because sometimes we get here twice?
                  if(a.alignment!=null && !a.alignment.startsWith("Target")) {
                      a.alignment = shorthand + a.alignment;

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/SubstanceSequenceFileSupportService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/SubstanceSequenceFileSupportService.java
@@ -1,0 +1,120 @@
+package gsrs.module.substance.services;
+
+import gov.nih.ncats.common.sneak.Sneak;
+import gsrs.repository.PayloadRepository;
+import gsrs.sequence.SequenceFileSupport;
+import gsrs.service.PayloadService;
+import ix.core.models.Payload;
+import ix.core.models.SequenceEntity;
+import ix.ginas.models.v1.Substance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+@Service
+public class SubstanceSequenceFileSupportService {
+
+    private static Pattern PAYLOAD_UUID_PATTERN = Pattern.compile("payload\\((.+?)\\)");
+
+    private final PayloadService payloadService;
+    private final PayloadRepository payloadRepository;
+
+    private final PlatformTransactionManager transactionManager;
+
+    @Autowired
+    public SubstanceSequenceFileSupportService(PayloadService payloadService,
+                                               PayloadRepository payloadRepository,
+                                               PlatformTransactionManager transactionManager) {
+        this.payloadService = payloadService;
+        this.payloadRepository = payloadRepository;
+        this.transactionManager = transactionManager;
+    }
+
+    public boolean hasSequenceFiles(Substance s){
+        return getFastaPayloadIdsFor(s).findAny().isPresent();
+    }
+
+    private Stream<String> getFastaPayloadIdsFor(Substance s){
+        return s.references.stream()
+                .filter(r -> r.uploadedFile != null)
+                .flatMap(r -> {
+                    if (r.tags.stream()
+//											.peek(k -> System.out.println(k))
+                            .filter(k -> k.term.equalsIgnoreCase("fasta"))
+                            .findAny()
+                            .isPresent()) {
+                        Matcher m = PAYLOAD_UUID_PATTERN.matcher(r.uploadedFile);
+                        if (m.find()) {
+                            return Stream.of(m.group(1));
+                        }
+                    }
+                        return Stream.empty();
+                    });
+    }
+
+
+    public <T extends Substance> Stream<SequenceFileSupport.SequenceFileData> getSequenceFileDataFor(T sequenceSubstance, SequenceEntity.SequenceType sequenceType){
+        return getFastaPayloadIdsFor(sequenceSubstance)
+                //TODO: hardcode fasta for now we can add more file types if we ever add support for others
+                .map(id-> new PayloadBackedSequenceFileData(sequenceType,
+                                                        SequenceFileSupport.SequenceFileData.SequenceFileType.FASTA,
+                                                        UUID.fromString(id)));
+    }
+
+    private class PayloadBackedSequenceFileData implements SequenceFileSupport.SequenceFileData{
+        private final SequenceEntity.SequenceType type;
+        private final SequenceFileType getSequenceFileType;
+        private final UUID payloadUUID;
+
+        public PayloadBackedSequenceFileData(SequenceEntity.SequenceType type, SequenceFileType getSequenceFileType, UUID payloadUUID) {
+            this.type = type;
+            this.payloadUUID = payloadUUID;
+            this.getSequenceFileType = getSequenceFileType;
+        }
+
+        @Override
+        public SequenceEntity.SequenceType getSequenceType() {
+            return type;
+        }
+
+        @Override
+        public SequenceFileType getSequenceFileType() {
+
+            return getSequenceFileType;
+        }
+
+        @Override
+        public InputStream createInputStream() throws IOException {
+            //we need to make sure we're in a transaction
+            TransactionTemplate tx = new TransactionTemplate(transactionManager);
+            Optional<InputStream> in= tx.execute( ignored -> {try {
+                return payloadService.getPayloadAsInputStream(payloadUUID);
+            }catch(IOException e){
+                return Sneak.sneakyThrow(e);
+            }});
+            if(in.isPresent()){
+                return in.get();
+            }
+            throw new IOException("could not find inputstream for payload " + payloadUUID);
+        }
+
+        @Override
+        public String getName() {
+            Optional<Payload> payload= payloadRepository.findById(payloadUUID);
+            if(!payload.isPresent()) {
+                return null;
+            }
+            return payload.get().name;
+        }
+    }
+
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/SubstanceSequenceFileSupportService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/SubstanceSequenceFileSupportService.java
@@ -20,6 +20,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+/**
+ * Helper Service that knows how to pull out
+ * sequence files that are attached to Substances as References
+ * so we can attach sequence files for long sequences.
+ */
 @Service
 public class SubstanceSequenceFileSupportService {
 

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/NucleicAcidSubstance.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/NucleicAcidSubstance.java
@@ -1,19 +1,24 @@
 package ix.ginas.models.v1;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import gsrs.module.substance.services.SubstanceSequenceFileSupportService;
+import gsrs.sequence.SequenceFileSupport;
+import gsrs.springUtils.StaticContextAccessor;
+import ix.core.models.SequenceEntity;
 import ix.ginas.models.GinasAccessReferenceControlled;
 import ix.ginas.models.GinasSubstanceDefinitionAccess;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
-import java.util.*;
+import java.util.List;
+import java.util.stream.Stream;
 
 @Entity
 @Inheritance
 @DiscriminatorValue("NA")
 @Slf4j
 //@JSONEntity(name = "nucleicAcidSubstance", title = "Nucleic Acid Substance")
-public class NucleicAcidSubstance extends Substance implements GinasSubstanceDefinitionAccess{
+public class NucleicAcidSubstance extends Substance implements GinasSubstanceDefinitionAccess, SequenceFileSupport {
 	@OneToOne(cascade= CascadeType.ALL)
 	public NucleicAcid nucleicAcid;
 
@@ -127,92 +132,22 @@ public class NucleicAcidSubstance extends Substance implements GinasSubstanceDef
 		return temp;
 	}
 
-//	@Override
-//	protected void additionalDefinitionalElements(Consumer<DefinitionalElement> consumer) {
-//		if(nucleicAcid ==null || nucleicAcid.subunits ==null){
-//			return;
-//		}
-//		/*for(Subunit s : this.nucleicAcid.subunits){
-//			if(s !=null && s.sequence !=null){
-//				NucleotideSequence seq = NucleotideSequence.of(Nucleotide.cleanSequence(s.sequence));
-//				UUID uuid = s.getOrGenerateUUID();
-//				consumer.accept(DefinitionalElement.of("subunitIndex."+ uuid, s.subunitIndex==null? null: Integer.toString(s.subunitIndex)));
-//				consumer.accept(DefinitionalElement.of("subunitSeq."+ uuid , seq.toString()));
-//				consumer.accept(DefinitionalElement.of("subunitSeqLength."+ uuid , Long.toString(seq.getLength())));
-//
-//			}
-//		}*/
-//		performAddition(this.nucleicAcid, consumer, Collections.newSetFromMap(new IdentityHashMap<>()));
-//	}
-//
-//	private void performAddition(NucleicAcid nucleicAcid, Consumer<DefinitionalElement> consumer, Set<NucleicAcid> visited)
-//	{
-//		log.debug("performAddition of nucleic acid substance");
-//		if (nucleicAcid != null )
-//		{
-//			visited.add(nucleicAcid);
-//			log.debug("main part");
-//			List<DefinitionalElement>	definitionalElements = additionalElementsFor();
-//			for(DefinitionalElement de : definitionalElements)
-//			{
-//				log.debug("adding DE with key " + de.getKey() + " to consumer for a NA");
-//				consumer.accept(de);
-//			}
-//			log.debug("DE processing complete");
-//		}
-//	}
-//
-//	public List<DefinitionalElement> additionalElementsFor() {
-//		List<DefinitionalElement> definitionalElements = new ArrayList<>();
-//
-//		if(this.nucleicAcid !=null) {
-//			//this can happen be null for incomplete? so we should check it
-//
-//			if(this.nucleicAcid.subunits !=null) {
-//				for (int i = 0; i < this.nucleicAcid.subunits.size(); i++) {
-//					Subunit s = this.nucleicAcid.subunits.get(i);
-//					log.debug("processing subunit with sequence " + s.sequence);
-//					DefinitionalElement sequenceHash = DefinitionalElement.of("nucleicAcid.subunits.sequence", s.sequence, 1);
-//					definitionalElements.add(sequenceHash);
-//				}
-//			}
-//
-//			if(this.nucleicAcid.linkages !=null) {
-//				for (int i = 0; i < this.nucleicAcid.linkages.size(); i++) {
-//					Linkage l = this.nucleicAcid.linkages.get(i);
-//					log.debug("processing linkage " + l.getLinkage());
-//					DefinitionalElement linkageHash = DefinitionalElement.of("nucleicAcid.linkages.linkage", l.getLinkage(), 2);
-//					definitionalElements.add(linkageHash);
-//
-//					//check if siteContainer is null
-//					if(l.siteContainer!=null) {
-//						log.debug("processing l.siteContainer.sitesShortHand " + l.siteContainer.sitesShortHand);
-//						DefinitionalElement siteElement = DefinitionalElement.of("nucleicAcid.linkages.site", l.siteContainer.sitesShortHand, 2);
-//						definitionalElements.add(siteElement);
-//					}
-//				}
-//
-//			}
-//			if(this.nucleicAcid.sugars !=null) {
-//				for (int i = 0; i < this.nucleicAcid.sugars.size(); i++) {
-//					Sugar s = this.nucleicAcid.sugars.get(i);
-//					log.debug("processing sugar " + s.sugar);
-//					DefinitionalElement sugarElement = DefinitionalElement.of("nucleicAcid.sugars.sugar", s.sugar, 2);
-//					definitionalElements.add(sugarElement);
-//					//check if siteContainer is null
-//					if(s.siteContainer!=null) {
-//						log.debug("processing s.siteContainer.sitesShortHand " + s.siteContainer.sitesShortHand);
-//						DefinitionalElement siteElement = DefinitionalElement.of("nucleicAcid.sugars.site", s.siteContainer.sitesShortHand, 2);
-//						definitionalElements.add(siteElement);
-//					}
-//				}
-//			}
-//		}
-//
-//		if( this.modifications != null ){
-//			definitionalElements.addAll(this.modifications.getDefinitionalElements().getElements());
-//		}
-//
-//		return definitionalElements;
-//	}
+	@Override
+	public boolean hasSequenceFiles() {
+		SubstanceSequenceFileSupportService supportService =  StaticContextAccessor.getBean(SubstanceSequenceFileSupportService.class);
+		if(supportService ==null){
+			return false;
+		}
+		return supportService.hasSequenceFiles(this);
+	}
+
+	@JsonIgnore
+	@Override
+	public Stream<SequenceFileData> getSequenceFileData() {
+		SubstanceSequenceFileSupportService supportService =  StaticContextAccessor.getBean(SubstanceSequenceFileSupportService.class);
+		if(supportService ==null){
+			return Stream.empty();
+		}
+		return supportService.getSequenceFileDataFor(this, SequenceEntity.SequenceType.NUCLEIC_ACID);
+	}
 }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/ProteinSubstance.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/ProteinSubstance.java
@@ -3,6 +3,10 @@ package ix.ginas.models.v1;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import gsrs.module.substance.definitional.DefinitionalElement;
+import gsrs.module.substance.services.SubstanceSequenceFileSupportService;
+import gsrs.sequence.SequenceFileSupport;
+import gsrs.springUtils.StaticContextAccessor;
+import ix.core.models.SequenceEntity;
 import ix.core.util.EntityUtils;
 import ix.core.util.LogUtil;
 import ix.ginas.models.GinasAccessReferenceControlled;
@@ -13,13 +17,14 @@ import javax.persistence.*;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 @SuppressWarnings("serial")
 @Entity
 @Inheritance
 @DiscriminatorValue("PRO")
 @Slf4j
-public class ProteinSubstance extends Substance implements GinasSubstanceDefinitionAccess {
+public class ProteinSubstance extends Substance implements GinasSubstanceDefinitionAccess, SequenceFileSupport {
 
 	@OneToOne(cascade= CascadeType.ALL)
     public Protein protein;
@@ -107,80 +112,6 @@ public class ProteinSubstance extends Substance implements GinasSubstanceDefinit
 		return temp;
 	}
 
-
-//	@Override
-//	protected void additionalDefinitionalElements(Consumer<DefinitionalElement> consumer) {
-//		if(protein ==null || protein.subunits ==null){
-//			return;
-//		}
-//		log.trace("Starting in additionalDefinitionalElements for protein" );
-//		try	{
-//			this.copy()
-//						.canonicalize()
-//						.addDefinitionalElements(consumer);
-//		}
-//		catch(JsonProcessingException ex){
-//			log.error("error during definitional hash processing: " + ex.getMessage());
-//			ex.printStackTrace();
-//		}
-//	}
-//
-//	private void addDefinitionalElements(Consumer<DefinitionalElement> consumer) {
-//		log.trace("starting in ProteinSubstance.addDefinitionalElements");
-//		for(Subunit s : this.protein.subunits){
-//			if(s !=null && s.sequence !=null){
-//				ProteinSequence seq = ProteinSequence.of(AminoAcid.cleanSequence(s.sequence));
-//				UUID uuid = s.getOrGenerateUUID();
-//				consumer.accept(DefinitionalElement.of("subunitIndex.", s.subunitIndex==null? null: Integer.toString(s.subunitIndex), 1));
-//				consumer.accept(DefinitionalElement.of("subunitSeq.", seq.toString(), 1));
-//				consumer.accept(DefinitionalElement.of("subunitSeqLength.", Long.toString(seq.getLength()), 1));
-//
-//			}
-//		}
-//
-//		Glycosylation glycosylation = this.protein.glycosylation;
-//		if(glycosylation !=null){
-//			handleGlycosylationSites(glycosylation.getNGlycosylationSites(), "N", consumer);
-//			handleGlycosylationSites(glycosylation.getOGlycosylationSites(), "O", consumer);
-//			handleGlycosylationSites(glycosylation.getCGlycosylationSites(), "C", consumer);
-//			if(glycosylation.glycosylationType !=null){
-//				consumer.accept(DefinitionalElement.of("protein.glycosylation.type", glycosylation.glycosylationType, 2));
-//			}
-//		}
-//		List<DisulfideLink> disulfideLinks = this.protein.getDisulfideLinks();
-//		if(disulfideLinks !=null){
-//			for(DisulfideLink disulfideLink : disulfideLinks){
-//				if(disulfideLink !=null) {
-//					consumer.accept(DefinitionalElement.of("protein.disulfide", disulfideLink.getSitesShorthand(), 2));
-//				}
-//			}
-//		}
-//
-//		List<OtherLinks> otherLinks = this.protein.otherLinks;
-//		if(otherLinks !=null){
-//			for(OtherLinks otherLink : otherLinks){
-//				if(otherLink ==null){
-//					continue;
-//				}
-//				List<Site> sites = otherLink.getSites();
-//				if(sites !=null) {
-//					String shortHand = SiteContainer.generateShorthand(sites);
-//					consumer.accept(DefinitionalElement.of("protein."+shortHand, shortHand, 2));
-//					String type = otherLink.linkageType;
-//					if(type !=null){
-//						consumer.accept(DefinitionalElement.of("protein."+shortHand +".linkageType", type, 2));
-//					}
-//				}
-//			}
-//		}
-//
-//		if (this.modifications != null) {
-//			for(DefinitionalElement element : this.modifications.getDefinitionalElements().getElements()) {
-//				consumer.accept(element);
-//			}
-//		}
-//	}
-//
 	public ProteinSubstance copy() throws JsonProcessingException {
 		log.trace("in ProteinSubstance.copy method");
 			return EntityUtils.EntityWrapper.of(this).getClone();
@@ -316,5 +247,24 @@ public class ProteinSubstance extends Substance implements GinasSubstanceDefinit
 			translatedSites.add(new Site(newSubunit, site.residueIndex));
 		}
 		return translatedSites;
+	}
+
+	@Override
+	public boolean hasSequenceFiles() {
+		SubstanceSequenceFileSupportService supportService =  StaticContextAccessor.getBean(SubstanceSequenceFileSupportService.class);
+		if(supportService ==null){
+			return false;
+		}
+		return supportService.hasSequenceFiles(this);
+	}
+
+	@JsonIgnore
+	@Override
+	public Stream<SequenceFileData> getSequenceFileData() {
+		SubstanceSequenceFileSupportService supportService =  StaticContextAccessor.getBean(SubstanceSequenceFileSupportService.class);
+		if(supportService ==null){
+			return Stream.empty();
+		}
+		return supportService.getSequenceFileDataFor(this, SequenceEntity.SequenceType.PROTEIN);
 	}
 }

--- a/gsrs-module-substances-spring-boot-autoconfigure/src/main/java/gsrs/module/substance/autoconfigure/GsrsSubstanceModuleAutoConfiguration.java
+++ b/gsrs-module-substances-spring-boot-autoconfigure/src/main/java/gsrs/module/substance/autoconfigure/GsrsSubstanceModuleAutoConfiguration.java
@@ -86,7 +86,7 @@ public class GsrsSubstanceModuleAutoConfiguration {
     @Bean("SubstanceSequenceSearchService")
     @ConditionalOnMissingBean(SubstanceSequenceSearchService.class)
     public SubstanceSequenceSearchService getSequenceSearchService(){
-        return new LegacySubstanceSequenceSearchService(sequenceIndexerService, ixCache,payloadService,
+        return new LegacySubstanceSequenceSearchService(sequenceIndexerService, ixCache,
                 proteinSubstanceRepository, nucleicAcidSubstanceRepository, subunitRepository);
     }
 


### PR DESCRIPTION
This is the PR to add fasta sequence searching support for Substances.  This corresponds to the starter PR https://github.com/ncats/gsrs-spring-starter/pull/60 

here's how it will work 

1. user adds a reference to an NucleicAcidSubstance or ProteinSubstance which now implement the new `SequenceFileSupport` interface
2. Attach a file containing sequence data
  * currently only FASTA format supported.
3.  the reference must add the tag "fasta" (we should probably add this to the CV)

On indexing the methods in SequenceFileSupport will fetch the fasta file which was previously uploaded as a Payload.  To figure out the payload UUID from the reference we assume the `Reference.url` field is API call to fetch that payload.  That is how the current Beta UI is designed so it works.

There is a "mixin" class `SubstanceSequenceFileSupportService` that NucleicAcidSubstance and ProteinSubstance delegate to that does all this logic of fetching the payload from references etc so we don't have duplicate logic.