### PR TITLE
WIP: Add extra clean step before trying to generate inchi

### DIFF
--- a/gsrs-module-substances-core/src/main/java/ix/core/chem/Chem.java
+++ b/gsrs-module-substances-core/src/main/java/ix/core/chem/Chem.java
@@ -6,6 +6,7 @@ import ix.core.models.Structure;
 import ix.core.util.LogUtil;
 import lombok.extern.slf4j.Slf4j;
 
+import ix.core.chem.ChemCleaner;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -39,7 +40,11 @@ public class Chem {
                         a.setMassNumber(6);
                     });
         }
-        return chemicalToUse;
+        try{
+                return Chemical.parse(ChemCleaner.removeSGroupsAndLegacyAtomLists(c.toMol()));
+        }catch(Exception e){
+                return chemicalToUse;
+        }
     }
 
 


### PR DESCRIPTION
This attempts to address GSRS-2512, where E/Z compounds that also have MUL SGROUPs can't generate an inchi.