### PR TITLE
Get rid of loophole allowing display name changes.

### DIFF
--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NamesValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NamesValidator.java
@@ -279,7 +279,6 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
                 e.printStackTrace();
             }
             if(oldDisplayName.isPresent() && n.displayName && !oldDisplayName.get().name.equalsIgnoreCase(n.name)
-                    && s.names.stream().anyMatch(nm->nm.name.equals(oldDisplayName.get().name)) //make sure the old display name is still present
                 &&  (s.changeReason==null || !s.changeReason.equalsIgnoreCase(CHANGE_REASON_DISPLAYNAME_CHANGED))) {
                 GinasProcessingMessage mes = GinasProcessingMessage
                         .WARNING_MESSAGE(


### PR DESCRIPTION
Warn users if change display name, even if it's a direct change to the name.