### PR TITLE
fixed multi-facet bug

### DIFF
--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/SubstanceController.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/SubstanceController.java
@@ -583,13 +583,20 @@ public class SubstanceController extends EtagLegacySearchEntityController<Substa
 
             attributes.mergeAttributes(sanitizedRequest.getParameterMap());
             attributes.addAttribute("q", hash);
-            attributes.addAttribute("includeBreakdown", false);
-            
             Optional.ofNullable(httpServletRequest.getParameterValues("facet")).ifPresent(ss->{
-                attributes.addAttribute("facet", ss);    
+                //In the spring RedirectAttributes object, adding String[] arrays
+                //directly turns the arrays into a single String comma separated.
+                //Instead, we want to set multiple values. The "asMap" method
+                //is tied to the real model as a Map and can be directly modified.
+                //However, the "put" and "putAll" methods are still overridden to
+                //serialize the String[] arrays. However, "putIfAbsent" is not
+                //overridden, so the String[] can be stored directly in this way.
+                //This works for when attributes is an instance of RedirectAttributesModelMap
+                //which it currently is.
+                attributes.asMap().putIfAbsent("facet", ss);
             });
             Optional.ofNullable(httpServletRequest.getParameterValues("order")).ifPresent(ss->{
-                attributes.addAttribute("order", ss);    
+                attributes.asMap().putIfAbsent("order", ss);
             });
             
             // do a text search for that hash value?


### PR DESCRIPTION
A fix for the fix to GSRS-2526.

Long story short: The redirect mechanism used by Spring-Boot will encode `String[]` as a serialized single String, which collapses multiple facet values in query params into one single one comma separated. To fix this a different mechanism for adding query params to redirects was needed, involving a non-overridden method.