### PR TITLE
WIP: reverted breakdown restriction

### DIFF
--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/SubstanceController.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/SubstanceController.java
@@ -583,6 +583,7 @@ public class SubstanceController extends EtagLegacySearchEntityController<Substa
 
             attributes.mergeAttributes(sanitizedRequest.getParameterMap());
             attributes.addAttribute("q", hash);
+            attributes.addAttribute("includeBreakdown", false);
             Optional.ofNullable(httpServletRequest.getParameterValues("facet")).ifPresent(ss->{
                 //In the spring RedirectAttributes object, adding String[] arrays
                 //directly turns the arrays into a single String comma separated.


### PR DESCRIPTION
When doing a flex search it shouldn't show up as a dropdown, but instead should show the smarts / structure pieces. Right now it shows this:
![image](https://user-images.githubusercontent.com/1581898/164720811-e6fd184e-c42f-469d-96f0-481b1119193b.png)

But an exact looks like this:
![image](https://user-images.githubusercontent.com/1581898/164720929-43604a3b-c8be-4071-81c4-7ed44a5e1815.png)

This is due to an accidentally deleted line. This PR should fix.