### PR TITLE
fix Redirection

### DIFF
--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/LegacyGinasAppController.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/LegacyGinasAppController.java
@@ -246,7 +246,7 @@ public class LegacyGinasAppController {
         if(standardize !=null){
             attributes.addAttribute("standardize", standardize);
         }
-        return new ModelAndView("redirect:/api/v1/substances/render(" +id +")");
+        return new ModelAndView("/api/v1/substances/render(" +id +")");
     }
 
     //GET	 /render	ix.ncats.controllers.App.renderParam(structure: String ?= null, size: Int ?= 150)
@@ -305,7 +305,7 @@ public class LegacyGinasAppController {
     public Object suggestFields(HttpServletRequest httpRequest, RedirectAttributes attributes) throws IOException {
         httpRequest.setAttribute(
                 View.RESPONSE_STATUS_ATTRIBUTE, HttpStatus.MOVED_PERMANENTLY);
-        return new ModelAndView("redirect:/api/v1/substances/suggest/@fields");
+        return new ModelAndView("/api/v1/substances/suggest/@fields");
     }
     @GetGsrsRestApiMapping("/suggest")
     public Object suggest(@RequestParam(value ="q") String q, @RequestParam(value ="max", defaultValue = "10") int max,
@@ -314,7 +314,7 @@ public class LegacyGinasAppController {
                 View.RESPONSE_STATUS_ATTRIBUTE, HttpStatus.MOVED_PERMANENTLY);
         attributes.addAttribute("q", q);
         attributes.addAttribute("max", max);
-        return new ModelAndView("redirect:/api/v1/substances/suggest");
+        return new ModelAndView("/api/v1/substances/suggest");
     }
     @GetGsrsRestApiMapping("/suggest/{field}")
     public Object suggestField(@PathVariable("field") String field,  @RequestParam("q") String q, @RequestParam(value ="max", defaultValue = "10") int max,
@@ -323,6 +323,6 @@ public class LegacyGinasAppController {
                     View.RESPONSE_STATUS_ATTRIBUTE, HttpStatus.MOVED_PERMANENTLY);
             attributes.addAttribute("q", q);
             attributes.addAttribute("max", max);
-            return new ModelAndView("redirect:/api/v1/substances/suggest/" + field);
+            return new ModelAndView("/api/v1/substances/suggest/" + field);
     }
 }

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/SubstanceController.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/SubstanceController.java
@@ -509,7 +509,7 @@ public class SubstanceController extends EtagLegacySearchEntityController<Substa
         if(sync) {
             attributes.addAttribute("sync", true);
         }
-        return new ModelAndView("redirect:/api/v1/substances/structureSearch");
+        return new ModelAndView("/api/v1/substances/structureSearch");
     }
 
     @GetGsrsRestApiMapping("/structureSearch")
@@ -603,7 +603,7 @@ public class SubstanceController extends EtagLegacySearchEntityController<Substa
             // do a text search for that hash value?
             // This technically breaks things, but is probably okay for now
             //
-            return new ModelAndView("redirect:/api/v1/substances/search");
+            return new ModelAndView("/api/v1/substances/search");
         }
         SearchResultContext resultContext=null;
         if(sanitizedRequest.getType() == SubstanceStructureSearchService.StructureSearchType.SUBSTRUCTURE
@@ -750,7 +750,7 @@ public class SubstanceController extends EtagLegacySearchEntityController<Substa
         if(sync) {
             attributes.addAttribute("sync", true);
         }
-        return new ModelAndView("redirect:/api/v1/substances/sequenceSearch");
+        return new ModelAndView("/api/v1/substances/sequenceSearch");
 
     }
     static String getOrderedKey (SearchResultContext context, SearchRequest request) {


### PR DESCRIPTION
This PR force the Controllers to use 'forward' instead of 'redirect'. This solves the '/img' path redirection problem on the all-in-one Tomcat deployment.