### PR TITLE
Testing build pipeline

### DIFF
--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NamesValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NamesValidator.java
@@ -115,6 +115,11 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
                 callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("name can not be null"));
                 continue;
             }
+            String forbiddenName="WOBBLEDOBBLE";
+            if( n.getName().contains(forbiddenName)) {
+                callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("You may not name substances " + forbiddenName));
+                continue;
+            }
             if (n.preferred) {
                 preferred = true;
             }


### PR DESCRIPTION
Adding a nonsense rule to the names validator that will probably never be triggered in real usage as a test for the build process.