### PR TITLE
restrict flex search to only 2 fields

### DIFF
--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/SubstanceController.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/SubstanceController.java
@@ -626,10 +626,11 @@ public class SubstanceController extends EtagLegacySearchEntityController<Substa
         }
 
         if(sanitizedRequest.getType() == SubstanceStructureSearchService.StructureSearchType.EXACT){
-            hash = "root_structure_properties_term:" + structure.getExactHash();
+            hash = "root_structure_properties_EXACT_HASH:" + structure.getExactHash();
         }else if(sanitizedRequest.getType() == SubstanceStructureSearchService.StructureSearchType.FLEX){
             //note we purposefully don't have the lucene path so it finds moieties and polymers etc
-            hash= structure.getStereoInsensitiveHash();
+            String sins=structure.getStereoInsensitiveHash();
+            hash= "( root_structure_properties_STEREO_INSENSITIVE_HASH:" + sins + " OR " + "root_moieties_properties_STEREO_INSENSITIVE_HASH:" + sins + " )";
         }
 
         if(hash !=null){

--- a/gsrs-module-substances-core/src/main/resources/substances-core.conf
+++ b/gsrs-module-substances-core/src/main/resources/substances-core.conf
@@ -28,14 +28,13 @@ ix.core.exactsearchfields=[
                         "root_codes_CAS",
                         "root_names_stdName",
                         "root_uuid",
-              		"root_structure_hash",
-              		"root_structure_formula",
-              		"root_structure_inchikey",
-              		"root_moieties_structure_inchikey",
-			"root_structure_properties_term",
-			"root_moieties_properties_STEREO_INSENSITIVE_HASH",
-			"root_moieties_properties_term",
-              		"root_codes_BDNUM"
+                        "root_structure_hash",
+                        "root_structure_formula",
+                        "root_structure_inchikey",
+                        "root_moieties_structure_inchikey",
+                        "root_structure_properties_term",
+                        "root_moieties_properties_term",
+                        "root_codes_BDNUM"
                 ]
         }
 ]


### PR DESCRIPTION
Flex search currently works by computing a stereo insensitive hash with a structure hasher and then searching _all_ fields for that text-based hash. If that hash is found in comments, a name, a note, etc it will still come back as a flex match.

Recently we've also introduced the idea of an "identifiers" default field. Flex search was using that identifiers field by default, rather than the full text field, which means that any field that would have the hash must be marked as an identifier for it to work. This is generally good except that we also show an "exact match" screen which is confusing to users. By restricting to the 2 fields where stereo insensitive hashes are stored it bypasses these issues.