### PR TITLE
standardize fields for hash indexes

### DIFF
--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/indexers/ChemicalSubstanceStructureHashIndexValueMaker.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/indexers/ChemicalSubstanceStructureHashIndexValueMaker.java
@@ -73,14 +73,19 @@ public class ChemicalSubstanceStructureHashIndexValueMaker implements IndexValue
 
     }
     
-    private void addHashes(String stereoInsensitive, String exact, String prefix, Consumer<IndexableValue> consumer) {
+    public static void addHashes(String stereoInsensitive, String exact, String prefix, Consumer<IndexableValue> consumer) {
 
-        consumer.accept(IndexableValue.simpleStringValue(prefix + "_term", stereoInsensitive));
-        consumer.accept(IndexableValue.simpleStringValue(prefix + "_term", exact));
-        consumer.accept(IndexableValue.simpleStringValue(prefix, exact));
-        consumer.accept(IndexableValue.simpleStringValue(prefix, stereoInsensitive));
-        consumer.accept(IndexableValue.simpleStringValue(prefix + "_STEREO_INSENSITIVE_HASH", stereoInsensitive));
-        consumer.accept(IndexableValue.simpleStringValue(prefix + "_EXACT_HASH", exact));
+        if(stereoInsensitive!=null) {
+            consumer.accept(IndexableValue.simpleStringValue(prefix + "_term", stereoInsensitive));
+            consumer.accept(IndexableValue.simpleStringValue(prefix, stereoInsensitive));
+            consumer.accept(IndexableValue.simpleStringValue(prefix + "_STEREO_INSENSITIVE_HASH", stereoInsensitive));
+        }
+        
+        if(exact!=null) {
+            consumer.accept(IndexableValue.simpleStringValue(prefix + "_term", exact));
+            consumer.accept(IndexableValue.simpleStringValue(prefix, exact));
+            consumer.accept(IndexableValue.simpleStringValue(prefix + "_EXACT_HASH", exact));
+        }
         
         
     }

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/indexers/MixtureStructureHashIndexValueMaker.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/indexers/MixtureStructureHashIndexValueMaker.java
@@ -56,18 +56,18 @@ public class MixtureStructureHashIndexValueMaker implements IndexValueMaker<Subs
 	public void extractStructureHashes(ChemicalSubstance s, Consumer<IndexableValue> consumer) {
 		
 		//consumer.accept(IndexableValue.simpleStringValue("root_structure_properties_term", lychi3));
-		if( s.getStructure().getStereoInsensitiveHash() != null && s.getStructure().getStereoInsensitiveHash().length() > 0)
-		{
-		consumer.accept(IndexableValue.simpleStringValue("root_structure_properties_term", s.getStructure().getStereoInsensitiveHash()));
-		}
-		if(s.getStructure().getExactHash() != null && s.getStructure().getExactHash().length() >0 )
-		{
-		consumer.accept(IndexableValue.simpleStringValue("root_structure_properties_term", s.getStructure().getExactHash()));
-		}
+	    
 
+        String stereoInsensitive=s.getStructure().getStereoInsensitiveHash();
+        String exact=s.getStructure().getExactHash();          
+        
+        ChemicalSubstanceStructureHashIndexValueMaker.addHashes(stereoInsensitive, exact, "root_structure_properties", consumer);
+
+        
 		s.moieties.stream().forEach(m->{
-			consumer.accept(IndexableValue.simpleStringValue("root_moieties_structure_properties_term", m.structure.getStereoInsensitiveHash()));
-			consumer.accept(IndexableValue.simpleStringValue("root_moieties_structure_properties_term", m.structure.getExactHash()));
+		    String sins=m.structure.getStereoInsensitiveHash();
+            String exa=m.structure.getExactHash();
+            ChemicalSubstanceStructureHashIndexValueMaker.addHashes(sins, exa, "root_moieties_properties", consumer);
 		});
 		
 	}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/indexers/ModificationStructureHashIndexValueMaker.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/indexers/ModificationStructureHashIndexValueMaker.java
@@ -62,21 +62,11 @@ public class ModificationStructureHashIndexValueMaker implements IndexValueMaker
         //consumer.accept(IndexableValue.simpleStringValue("root_structure_properties_term", lychi3));
 		String stereoInsensitive=s.getStructure().getStereoInsensitiveHash();
 		String exact=s.getStructure().getExactHash();
-		if(stereoInsensitive!=null){
-			consumer.accept(IndexableValue.simpleStringValue("root_structure_properties_term", stereoInsensitive));
-		}
-		if(exact!=null){
-			consumer.accept(IndexableValue.simpleStringValue("root_structure_properties_term", exact));
-		}
+		ChemicalSubstanceStructureHashIndexValueMaker.addHashes(stereoInsensitive, exact, "root_structure_properties", consumer);
         s.moieties.stream().forEach(m->{
 			String sins=m.structure.getStereoInsensitiveHash();
 			String exa=m.structure.getExactHash();
-			if(sins!=null){
-				consumer.accept(IndexableValue.simpleStringValue("root_moieties_structure_properties_term", sins));
-			}
-			if(exa!=null){
-				consumer.accept(IndexableValue.simpleStringValue("root_moieties_structure_properties_term", exa));
-			}
+			ChemicalSubstanceStructureHashIndexValueMaker.addHashes(sins, exa, "root_moieties_properties", consumer);
         });
 
     }

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/indexers/PolymerStructureHashIndexValueMaker.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/indexers/PolymerStructureHashIndexValueMaker.java
@@ -46,15 +46,13 @@ public class PolymerStructureHashIndexValueMaker implements IndexValueMaker<Subs
             Structure structure = structureProcessor.instrument(s.polymer.displayStructure.molfile, components);
 
 
-
-
-            consumer.accept(IndexableValue.simpleStringValue("root_structure_properties_term", structure.getStereoInsensitiveHash()));
-            consumer.accept(IndexableValue.simpleStringValue("root_structure_properties_term", structure.getExactHash()));
-
-
+            String stereoInsensitive=structure.getStereoInsensitiveHash();
+            String exact=structure.getExactHash();            
+            ChemicalSubstanceStructureHashIndexValueMaker.addHashes(stereoInsensitive, exact, "root_structure_properties", consumer);
             components.forEach(m->{
-                consumer.accept(IndexableValue.simpleStringValue("root_moieties_structure_properties_term", m.getStereoInsensitiveHash()));
-                consumer.accept(IndexableValue.simpleStringValue("root_moieties_structure_properties_term", m.getExactHash()));
+                String sins=m.getStereoInsensitiveHash();
+                String exa=m.getExactHash();
+                ChemicalSubstanceStructureHashIndexValueMaker.addHashes(sins, exa, "root_moieties_properties", consumer);
             });
 
         }catch(Exception e){

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/SubstanceFieldNameDecorator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/SubstanceFieldNameDecorator.java
@@ -33,7 +33,18 @@ public class SubstanceFieldNameDecorator implements FieldNameDecorator {
 			
 			m.put("root_uuid" , "Substance UUID"); 
             m.put("root_structure_inchikey" , "InChIKey");
+            
             m.put("root_structure_properties_term" , "Structure Property");
+            m.put("root_structure_properties" , "Structure Property");
+            
+            m.put("root_moieties_properties_term" , "Moiety Structure Property");
+            m.put("root_moieties_properties" , "Moiety Structure Property");
+            
+            m.put("root_structure_properties_STEREO_INSENSITIVE_HASH" , "Structure Insensitive Hash");
+            m.put("root_structure_properties_EXACT_HASH" , "Structure Exact Hash");
+            
+            m.put("root_moieties_properties_STEREO_INSENSITIVE_HASH" , "Moiety Structure Insensitive Hash");
+            m.put("root_moieties_properties_EXACT_HASH" , "Moiety Structure Exact Hash");
             
 			m.put("root_names_stdName" , "Standardized Name");
 			m.put("root_Display Name","Display Name"); 


### PR DESCRIPTION
The terms we use for flex search for structures, polymers, modifications, mixtures hashes aren't entirely consistent. They need to be consistent. This should make them consistent.