### PR TITLE
Update ChemicalSubstanceDefinitionalElementImpl.java

### DIFF
--- a/gsrs-module-substance-example/pom.xml
+++ b/gsrs-module-substance-example/pom.xml
@@ -273,5 +273,11 @@
             <artifactId>ojdbc8</artifactId>
             <version>19.8.0.0</version>
             </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/gsrs-module-substance-example/src/test/java/example/chem/DefHashCalcTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/chem/DefHashCalcTest.java
@@ -1,0 +1,88 @@
+package example.chem;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gsrs.module.substance.definitional.ChemicalSubstanceDefinitionalElementImpl;
+import gsrs.module.substance.definitional.DefinitionalElement;
+import gsrs.substances.tests.AbstractSubstanceJpaEntityTest;
+import ix.core.chem.StructureProcessor;
+import ix.core.models.Structure;
+import ix.ginas.modelBuilders.ChemicalSubstanceBuilder;
+import ix.ginas.models.v1.ChemicalSubstance;
+import ix.ginas.models.v1.GinasChemicalStructure;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DefHashCalcTest extends AbstractSubstanceJpaEntityTest {
+
+    @Autowired
+    private StructureProcessor structureProcessor;
+
+    @Test
+    public void testOpticalInDefinitionalHashCalcNeg() throws Exception {
+        String opticalActivityKey="structure.properties.opticalActivity";
+        String structureJson = "{\n" +
+                "    \"opticalActivity\": \"UNSPECIFIED\",\n" +
+                "    \"molfile\": \"\\n  ACCLDraw07282209012D\\n\\n  5  4  0  0  0  0  0  0  0  0999 V2000\\n   10.5000   -8.5938    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\\n   11.5229   -8.0032    0.0000 C   0  0  3  0  0  0  0  0  0  0  0  0\\n   11.5229   -6.8217    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0\\n   12.5460   -8.5939    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\\n   13.5692   -8.0032    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\\n  1  2  1  0  0  0  0\\n  2  3  1  0  0  0  0\\n  2  4  1  0  0  0  0\\n  4  5  1  0  0  0  0\\nM  END\",\n" +
+                "    \"stereoCenters\": 1,\n" +
+                "    \"definedStereo\": 0,\n" +
+                "    \"ezCenters\": 0,\n" +
+                "    \"charge\": 0,\n" +
+                "    \"mwt\": 92.56726,\n" +
+                "    \"count\": 1,\n" +
+                "    \"stereochemistry\": \"RACEMIC\"\n" +
+                "}\n" +
+                "";
+        ObjectMapper om = new ObjectMapper();
+        Structure rawStructure = om.readValue(structureJson, Structure.class);
+        Structure instrumentedStructure =structureProcessor.instrument(rawStructure.toChemical(), true);
+        GinasChemicalStructure ginasChemicalStructure = new GinasChemicalStructure(instrumentedStructure);
+
+        ChemicalSubstanceBuilder builder = new ChemicalSubstanceBuilder();
+        ChemicalSubstance chem =builder
+                .setStructure(ginasChemicalStructure)
+                .addName("2-chlorobutane")
+                        .build();
+        ChemicalSubstanceDefinitionalElementImpl defHashCalculator = new ChemicalSubstanceDefinitionalElementImpl();
+        List<DefinitionalElement> definitionalElements = new ArrayList<>();
+        defHashCalculator.computeDefinitionalElements(chem, definitionalElements::add);
+        definitionalElements.forEach(de-> System.out.printf("key: %s = %s\n", de.getKey(), de.getValue()));
+        Assertions.assertTrue(definitionalElements.stream().noneMatch(de->de.getKey().equals(opticalActivityKey)));
+    }
+
+    @Test
+    public void testOpticalInDefinitionalHashCalcPos() throws Exception {
+        String opticalActivityKey="structure.properties.opticalActivity";
+        String structureJson = "{\n" +
+                "    \"opticalActivity\": \"POS\",\n" +
+                "    \"molfile\": \"\\n  ACCLDraw07282209012D\\n\\n  5  4  0  0  0  0  0  0  0  0999 V2000\\n   10.5000   -8.5938    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\\n   11.5229   -8.0032    0.0000 C   0  0  3  0  0  0  0  0  0  0  0  0\\n   11.5229   -6.8217    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0\\n   12.5460   -8.5939    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\\n   13.5692   -8.0032    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\\n  1  2  1  0  0  0  0\\n  2  3  1  0  0  0  0\\n  2  4  1  0  0  0  0\\n  4  5  1  0  0  0  0\\nM  END\",\n" +
+                "    \"stereoCenters\": 1,\n" +
+                "    \"definedStereo\": 0,\n" +
+                "    \"ezCenters\": 0,\n" +
+                "    \"charge\": 0,\n" +
+                "    \"mwt\": 92.56726,\n" +
+                "    \"count\": 1,\n" +
+                "    \"stereochemistry\": \"MIXED\"\n" +
+                "}\n" +
+                "";
+        ObjectMapper om = new ObjectMapper();
+        Structure rawStructure = om.readValue(structureJson, Structure.class);
+        Structure instrumentedStructure =structureProcessor.instrument(rawStructure.toChemical(), true);
+        GinasChemicalStructure ginasChemicalStructure = new GinasChemicalStructure(instrumentedStructure);
+
+
+        ChemicalSubstanceBuilder builder = new ChemicalSubstanceBuilder();
+        ChemicalSubstance chem =builder
+                .setStructure(ginasChemicalStructure)
+                .addName("2-chlorobutane")
+                .build();
+        chem.getStructure().setStereoChemistry(Structure.Stereo.MIXED);
+        ChemicalSubstanceDefinitionalElementImpl defHashCalculator = new ChemicalSubstanceDefinitionalElementImpl();
+        List<DefinitionalElement> definitionalElements = new ArrayList<>();
+        defHashCalculator.computeDefinitionalElements(chem, definitionalElements::add);
+        definitionalElements.forEach(de-> System.out.printf("key: %s = %s\n", de.getKey(), de.getValue()));
+        Assertions.assertTrue(definitionalElements.stream().anyMatch(de->de.getKey().equals(opticalActivityKey)));
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/definitional/ChemicalSubstanceDefinitionalElementImpl.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/definitional/ChemicalSubstanceDefinitionalElementImpl.java
@@ -34,12 +34,17 @@ public class ChemicalSubstanceDefinitionalElementImpl implements DefinitionalEle
             consumer.accept(DefinitionalElement.of("structure.properties.stereoChemistry",
                     structure.stereoChemistry.toString(), 2));
             log.debug("structure.stereoChemistry : " + structure.stereoChemistry.toString());
+            
+            if(structure.opticalActivity!=null){
+                String stereoTxt=structure.stereoChemistry.toString().toUpperCase();    
+                if(stereoTxt.equals("UNKNOWN") || stereoTxt.equals("MIXED") || stereoTxt.equals("EPIMERIC")){
+                    consumer.accept(DefinitionalElement.of("structure.properties.opticalActivity",
+                            structure.opticalActivity.toString(), 2));
+                    log.debug("structure.opticalActivity.toString(): " + structure.opticalActivity.toString());
+                }
+            }
         }
-        if(structure.opticalActivity!=null){
-            consumer.accept(DefinitionalElement.of("structure.properties.opticalActivity",
-                    structure.opticalActivity.toString(), 2));
-            log.debug("structure.opticalActivity.toString(): " + structure.opticalActivity.toString());
-        }
+      
         if( chemicalSubstance.moieties != null) {
             for(Moiety m: chemicalSubstance.moieties){
                 String mh=m.structure.getStereoInsensitiveHash();
@@ -50,9 +55,13 @@ public class ChemicalSubstanceDefinitionalElementImpl implements DefinitionalEle
                 consumer.accept(DefinitionalElement.of("moiety[" + mh + "].stereoChemistry",
                         m.structure.stereoChemistry.toString(), 2));
                 log.debug("m.structure.stereoChemistry.toString(): " + m.structure.stereoChemistry.toString());
-                consumer.accept(DefinitionalElement.of("moiety[" + mh + "].opticalActivity",
-                        m.structure.opticalActivity.toString(), 2));
-                log.debug("m.structure.opticalActivity.toString(): " + m.structure.opticalActivity.toString());
+                
+                String stereoTxt= m.structure.stereoChemistry.toString();
+                if(stereoTxt.equals("UNKNOWN") || stereoTxt.equals("MIXED") || stereoTxt.equals("EPIMERIC")){
+                    consumer.accept(DefinitionalElement.of("moiety[" + mh + "].opticalActivity",
+                            m.structure.opticalActivity.toString(), 2));
+                    log.debug("m.structure.opticalActivity.toString(): " + m.structure.opticalActivity.toString());
+                }
                 consumer.accept(DefinitionalElement.of("moiety[" + mh + "].countAmount",
                         m.getCountAmount().toString(), 2));
                 log.debug("m.getCountAmount().toString(): " + m.getCountAmount().toString());

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/definitional/ChemicalSubstanceDefinitionalElementImpl.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/definitional/ChemicalSubstanceDefinitionalElementImpl.java
@@ -6,9 +6,14 @@ import ix.ginas.models.v1.ChemicalSubstance;
 import ix.ginas.models.v1.Moiety;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Consumer;
 @Slf4j
 public class ChemicalSubstanceDefinitionalElementImpl implements DefinitionalElementImplementation {
+
+    private List<String> stereoUsingOpticalActivities = Arrays.asList( "UNKNOWN", "MIXED", "EPIMERIC");
+
     @Override
     public boolean supports(Object s) {
         return s instanceof ChemicalSubstance;
@@ -36,8 +41,9 @@ public class ChemicalSubstanceDefinitionalElementImpl implements DefinitionalEle
             log.debug("structure.stereoChemistry : " + structure.stereoChemistry.toString());
             
             if(structure.opticalActivity!=null){
-                String stereoTxt=structure.stereoChemistry.toString().toUpperCase();    
-                if(stereoTxt.equals("UNKNOWN") || stereoTxt.equals("MIXED") || stereoTxt.equals("EPIMERIC")){
+                String stereoTxt=structure.stereoChemistry.toString().toUpperCase();
+                if(stereoUsingOpticalActivities.contains(stereoTxt)){
+                    log.trace("using optical activity in def hash for structure");
                     consumer.accept(DefinitionalElement.of("structure.properties.opticalActivity",
                             structure.opticalActivity.toString(), 2));
                     log.debug("structure.opticalActivity.toString(): " + structure.opticalActivity.toString());
@@ -56,8 +62,9 @@ public class ChemicalSubstanceDefinitionalElementImpl implements DefinitionalEle
                         m.structure.stereoChemistry.toString(), 2));
                 log.debug("m.structure.stereoChemistry.toString(): " + m.structure.stereoChemistry.toString());
                 
-                String stereoTxt= m.structure.stereoChemistry.toString();
-                if(stereoTxt.equals("UNKNOWN") || stereoTxt.equals("MIXED") || stereoTxt.equals("EPIMERIC")){
+                String stereoTxt= m.structure.stereoChemistry.toString().toUpperCase();
+                if( stereoUsingOpticalActivities.contains(stereoTxt)){
+                    log.trace("using optical activity in def hash for moiety");
                     consumer.accept(DefinitionalElement.of("moiety[" + mh + "].opticalActivity",
                             m.structure.opticalActivity.toString(), 2));
                     log.debug("m.structure.opticalActivity.toString(): " + m.structure.opticalActivity.toString());


### PR DESCRIPTION
Optical activity isn't typically defining. It's only defining when the stereo is "UNKNOWN", "MIXED" or "EPIMERIC". In all other cases it's either programmatically deterministic (racemic=(+/-), achiral = none) or scientifically deterministic (absolutely-known chiral molecules have _some_ optical activity we just may not know it).

This changes the logic accodingly.