### PR TITLE
new codeProcessor configuration options

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/substance/datasource/DefaultCodeSystemUrlGeneratorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/datasource/DefaultCodeSystemUrlGeneratorTest.java
@@ -29,13 +29,14 @@ public class DefaultCodeSystemUrlGeneratorTest {
         String codeSystemForTest = "PubChem";
         String codeUrlForTest = "https://pubchem.ncbi.nlm.nih.gov/compound/$CODE$";
 
-        Map<String, String> codeSystemUrl = new HashMap<>();
-        codeSystemUrl.put(codeSystemForTest, codeUrlForTest);
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put("codeSystems", codeSystemUrl);
+        Map<String, String> configEntry = new HashMap<>();
+        configEntry.put("codeSystem", codeSystemForTest);
+        configEntry.put("url", codeUrlForTest);
+        Map<String, Map<String, String>> configMap = new HashMap<String, Map<String, String>>();
+        configMap.put("0", configEntry);
         DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap);
         Map map = generator.getMap();
-        
+
         assertTrue(map.size() >0);
     }
 
@@ -44,13 +45,14 @@ public class DefaultCodeSystemUrlGeneratorTest {
         String codeSystemForTest = "PubChem";
         String codeUrlForTest = "https://pubchem.ncbi.nlm.nih.gov/compound/$CODE$";
 
-        Map<String, String> codeSystemUrl = new HashMap<>();
-        codeSystemUrl.put(codeSystemForTest, codeUrlForTest);
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put("codeSystems", codeSystemUrl);
+        Map<String, String> configEntry = new HashMap<>();
+        configEntry.put("codeSystem", codeSystemForTest);
+        configEntry.put("url", codeUrlForTest);
+        Map<String, Map<String, String>> configMap = new HashMap<String, Map<String, String>>();
+        configMap.put("0", configEntry);
         DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap);
         CodeSystemMeta meta = generator.fetch(codeSystemForTest);
-        
+
         assertNotNull(meta);
     }
 
@@ -61,10 +63,11 @@ public class DefaultCodeSystemUrlGeneratorTest {
         String codeValueForTest = "5288826";
         String expectedUrl = "https://pubchem.ncbi.nlm.nih.gov/compound/5288826";
 
-        Map<String, String> codeSystemUrl = new HashMap<>();
-        codeSystemUrl.put(codeSystemForTest, codeUrlForTest);
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put("codeSystems", codeSystemUrl);
+        Map<String, String> configEntry = new HashMap<>();
+        configEntry.put("codeSystem", codeSystemForTest);
+        configEntry.put("url", codeUrlForTest);
+        Map<String, Map<String, String>> configMap = new HashMap<String, Map<String, String>>();
+        configMap.put("0", configEntry);
         DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap);
         Code code = new Code();
         code.code = codeValueForTest;
@@ -81,10 +84,11 @@ public class DefaultCodeSystemUrlGeneratorTest {
         String codeValueForTest = "a5b2c8d8e2f6";
         String expectedUrl = "http://www.drugbank.ca/drugs/a5b2c8d8e2f6";
 
-        Map<String, String> codeSystemUrl = new HashMap<>();
-        codeSystemUrl.put(codeSystemForTest, codeUrlForTest);
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put("codeSystems", codeSystemUrl);
+        Map<String, String> configEntry = new HashMap<>();
+        configEntry.put("codeSystem", codeSystemForTest);
+        configEntry.put("url", codeUrlForTest);
+        Map<String, Map<String, String>> configMap = new HashMap<String, Map<String, String>>();
+        configMap.put("0", configEntry);
         DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap);
         Code code = new Code();
         code.code = codeValueForTest;
@@ -103,10 +107,11 @@ public class DefaultCodeSystemUrlGeneratorTest {
         String codeTextForTest ="othervalue";
         String expectedUrl = "http://www.blah.com/drugs/othervalue";
 
-        Map<String, String> codeSystemUrl = new HashMap<>();
-        codeSystemUrl.put(codeSystemForTest, codeUrlForTest);
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put("codeSystems", codeSystemUrl);
+        Map<String, String> configEntry = new HashMap<>();
+        configEntry.put("codeSystem", codeSystemForTest);
+        configEntry.put("url", codeUrlForTest);
+        Map<String, Map<String, String>> configMap = new HashMap<String, Map<String, String>>();
+        configMap.put("0", configEntry);
         DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap);
         Code code = new Code();
         code.code = codeValueForTest;

--- a/gsrs-module-substance-example/src/test/java/example/substance/datasource/DefaultCodeSystemUrlGeneratorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/datasource/DefaultCodeSystemUrlGeneratorTest.java
@@ -34,7 +34,7 @@ public class DefaultCodeSystemUrlGeneratorTest {
         configEntry.put("url", codeUrlForTest);
         Map<String, Map<String, String>> configMap = new HashMap<String, Map<String, String>>();
         configMap.put("0", configEntry);
-        DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap);
+        DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap, null);
         Map map = generator.getMap();
 
         assertTrue(map.size() >0);
@@ -50,7 +50,7 @@ public class DefaultCodeSystemUrlGeneratorTest {
         configEntry.put("url", codeUrlForTest);
         Map<String, Map<String, String>> configMap = new HashMap<String, Map<String, String>>();
         configMap.put("0", configEntry);
-        DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap);
+        DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap, null);
         CodeSystemMeta meta = generator.fetch(codeSystemForTest);
 
         assertNotNull(meta);
@@ -68,7 +68,7 @@ public class DefaultCodeSystemUrlGeneratorTest {
         configEntry.put("url", codeUrlForTest);
         Map<String, Map<String, String>> configMap = new HashMap<String, Map<String, String>>();
         configMap.put("0", configEntry);
-        DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap);
+        DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap, null);
         Code code = new Code();
         code.code = codeValueForTest;
         code.codeSystem = codeSystemForTest;
@@ -89,7 +89,7 @@ public class DefaultCodeSystemUrlGeneratorTest {
         configEntry.put("url", codeUrlForTest);
         Map<String, Map<String, String>> configMap = new HashMap<String, Map<String, String>>();
         configMap.put("0", configEntry);
-        DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap);
+        DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap, null);
         Code code = new Code();
         code.code = codeValueForTest;
         code.codeSystem = codeSystemForTest;
@@ -112,7 +112,7 @@ public class DefaultCodeSystemUrlGeneratorTest {
         configEntry.put("url", codeUrlForTest);
         Map<String, Map<String, String>> configMap = new HashMap<String, Map<String, String>>();
         configMap.put("0", configEntry);
-        DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap);
+        DefaultCodeSystemUrlGenerator generator = new DefaultCodeSystemUrlGenerator(configMap, null);
         Code code = new Code();
         code.code = codeValueForTest;
         code.codeSystem = codeSystemForTest;

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/datasource/DefaultCodeSystemUrlGenerator.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/datasource/DefaultCodeSystemUrlGenerator.java
@@ -1,22 +1,19 @@
 package gsrs.module.substance.datasource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+import gsrs.module.substance.processors.CodeSystemUrlGenerator;
+import ix.ginas.models.v1.Code;
+
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gsrs.module.substance.processors.CodeSystemUrlGenerator;
-
-import ix.ginas.models.v1.Code;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ClassPathResource;
 
 @Slf4j
 public class DefaultCodeSystemUrlGenerator implements DataSet<CodeSystemMeta>, CodeSystemUrlGenerator {
@@ -24,42 +21,11 @@ public class DefaultCodeSystemUrlGenerator implements DataSet<CodeSystemMeta>, C
     @JsonIgnore
     private final Map<String, CodeSystemMeta> map = new LinkedHashMap<>();
 
-    public DefaultCodeSystemUrlGenerator(Map with) throws IOException {
-        Map<String, String> codeMaps = (Map<String, String>) with.get("codeSystems");
-        codeMaps.keySet().stream().map((codeSystem) -> {
-            String url = codeMaps.get(codeSystem);
-            CodeSystemMeta csmap = new CodeSystemMeta(codeSystem, url);
-            return csmap;
-        }).forEachOrdered((csmap) -> {
-            map.put(csmap.codeSystem.toLowerCase(), csmap);
-        });
-
-//        try(InputStream is=new ClassPathResource(filename).getInputStream();) {
-//            ObjectMapper mapper = new ObjectMapper();
-//            JsonNode tree = mapper.readTree(is);
-//
-//            for (JsonNode jsn : tree) {
-//                String cs = jsn.at("/codeSystem").asText();
-//                String url = jsn.at("/url").asText();
-//                CodeSystemMeta csmap = new CodeSystemMeta(cs, url);
-//                map.put(csmap.codeSystem.toLowerCase(), csmap);
-//            }
-//          }
-    }
-
     @JsonCreator
-    public DefaultCodeSystemUrlGenerator(@JsonProperty("filename") String filename) throws IOException {
-        ClassPathResource t= new ClassPathResource(filename);
-        try (InputStream is = new ClassPathResource(filename).getInputStream();) {
-            ObjectMapper mapper = new ObjectMapper();
-            JsonNode tree = mapper.readTree(is);
-
-            for (JsonNode jsn : tree) {
-                String cs = jsn.at("/codeSystem").asText();
-                String url = jsn.at("/url").asText();
-                CodeSystemMeta csmap = new CodeSystemMeta(cs, url);
-                map.put(csmap.codeSystem.toLowerCase(), csmap);
-            }
+    public DefaultCodeSystemUrlGenerator(@JsonProperty("codeSystems") Map<String, Map<String, String>> tree) throws IOException {
+        for (Map<String, String> entry : tree.values()) {
+            CodeSystemMeta csmap = new CodeSystemMeta(entry.get("codeSystem"), entry.get("url"));
+            map.put(csmap.codeSystem.toLowerCase(), csmap);
         }
     }
 
@@ -90,7 +56,7 @@ public class DefaultCodeSystemUrlGenerator implements DataSet<CodeSystemMeta>, C
 
         return Optional.ofNullable(meta.generateUrlFor(code));
     }
-    
+
     //used for testing --making sure the Map gets instantiated after a call to the constructor
     public Map getMap() {
         return map;


### PR DESCRIPTION
This PR make it possible to use codeSystems list within application.conf or including external codeSystem.json file to configure the DefaultCodeSystemUrlGenerator.

The existing codeSystem.json need to be slightly modified to be comatible with HOCON include statement.

Examples:
The new codeSystem.json example:
```
{"codeSystems: [
                {"codeSystem":"NCI_THESAURUS","url":"https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI%20Thesaurus&code=$CODE$"},
                {"codeSystem":"MESH","url":"https://www.ncbi.nlm.nih.gov/mesh/$CODE$"},    
                {"codeSystem":"UNIPROT","url":"http://www.uniprot.org/uniprot/$CODE$"} 
]}
```

Embeded Configuration:
```
gsrs.entityProcessors+=
{
    "entityClassName":"ix.ginas.models.v1.Substance",
    "processor":"gsrs.module.substance.processors.CodeProcessor",
    "with": {
        "class":"gsrs.module.substance.datasource.DefaultCodeSystemUrlGenerator",
        "json": {
            "codeSystems: [
                {"codeSystem":"NCI_THESAURUS","url":"https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI%20Thesaurus&code=$CODE$"},
                {"codeSystem":"MESH","url":"https://www.ncbi.nlm.nih.gov/mesh/$CODE$"},    
                {"codeSystem":"UNIPROT","url":"http://www.uniprot.org/uniprot/$CODE$"} 
            ]
    }
}
```

Include codeSystem.json from classpath:
```
gsrs.entityProcessors+=
{
    "entityClassName":"ix.ginas.models.v1.Substance",
    "processor":"gsrs.module.substance.processors.CodeProcessor",
    "with": {
        "class":"gsrs.module.substance.datasource.DefaultCodeSystemUrlGenerator",
        "json": { include classpath("codeSystem.json") }
    }
}
```

Include codeSystem.json from the file system:
```
gsrs.entityProcessors+=
{
    "entityClassName":"ix.ginas.models.v1.Substance",
    "processor":"gsrs.module.substance.processors.CodeProcessor",
    "with": {
        "class":"gsrs.module.substance.datasource.DefaultCodeSystemUrlGenerator",
        "json": { include file("/etc/gsrs/codeSystem.json") }
    }
}
```