### PR TITLE
use maven-renderer 1.0.13-SNAPSHOT

### DIFF
--- a/gsrs-module-substances-core/pom.xml
+++ b/gsrs-module-substances-core/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>gov.nih.ncats</groupId>
             <artifactId>molwitch-renderer</artifactId>
-            <version>1.0.12-SNAPSHOT</version>
+            <version>1.0.13-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>gov.nih.ncats</groupId>


### PR DESCRIPTION
This addresses a bracket-positioning issue found in certain polymers when GSRS uses JChem