### PR TITLE
GsrsProcessingStrategyFactory Configuration

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/substance/validation/BasicNameValidatorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/validation/BasicNameValidatorTest.java
@@ -18,7 +18,7 @@ import ix.core.validator.ValidationResponseBuilder;
 import ix.ginas.modelBuilders.ChemicalSubstanceBuilder;
 import ix.ginas.models.v1.ChemicalSubstance;
 import ix.ginas.models.v1.Substance;
-import ix.ginas.utils.GinasProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GinasProcessingStrategy;
 import ix.ginas.utils.validation.strategy.AcceptApplyAllProcessingStrategy;
 import ix.ginas.utils.validation.validators.BasicNameValidator;
 import lombok.extern.slf4j.Slf4j;

--- a/gsrs-module-substance-example/src/test/java/example/substance/validation/BasicNameValidatorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/validation/BasicNameValidatorTest.java
@@ -10,7 +10,6 @@ import gsrs.module.substance.standardizer.FDAFullNameStandardizer;
 import gsrs.module.substance.standardizer.FDAMinimumNameStandardizer;
 import gsrs.module.substance.standardizer.NameStandardizer;
 import gsrs.module.substance.standardizer.NameStandardizerConfiguration;
-import gsrs.services.GroupService;
 import gsrs.springUtils.AutowireHelper;
 import gsrs.substances.tests.AbstractSubstanceJpaEntityTest;
 import ix.core.validator.ValidationResponse;
@@ -18,8 +17,8 @@ import ix.core.validator.ValidationResponseBuilder;
 import ix.ginas.modelBuilders.ChemicalSubstanceBuilder;
 import ix.ginas.models.v1.ChemicalSubstance;
 import ix.ginas.models.v1.Substance;
-import ix.ginas.utils.validation.strategy.GinasProcessingStrategy;
-import ix.ginas.utils.validation.strategy.AcceptApplyAllProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GsrsProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GsrsProcessingStrategyFactory;
 import ix.ginas.utils.validation.validators.BasicNameValidator;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 public class BasicNameValidatorTest extends AbstractSubstanceJpaEntityTest {
 
     @Autowired
-    private GroupService groupService;
+    private GsrsProcessingStrategyFactory gsrsProcessingStrategyFactory;
 
     
 
@@ -97,7 +96,7 @@ public class BasicNameValidatorTest extends AbstractSubstanceJpaEntityTest {
                 .build();
         BasicNameValidator validator = new BasicNameValidator();
         validator=AutowireHelper.getInstance().autowireAndProxy(validator);
-        GinasProcessingStrategy strategy = createAcceptApplyAllStrategy();
+        GsrsProcessingStrategy strategy = createAcceptApplyAllStrategy();
         ValidationResponse<Substance> response2 = new ValidationResponse<>();
         ValidationResponseBuilder validationResponsebuilder = new ValidationResponseBuilder(chemical,
                 response2, strategy);
@@ -119,7 +118,7 @@ public class BasicNameValidatorTest extends AbstractSubstanceJpaEntityTest {
                 .build();
         BasicNameValidator validator = new BasicNameValidator();
         validator=AutowireHelper.getInstance().autowireAndProxy(validator);
-        GinasProcessingStrategy strategy = createAcceptApplyAllStrategy();
+        GsrsProcessingStrategy strategy = createAcceptApplyAllStrategy();
         ValidationResponse<Substance> response2 = new ValidationResponse<>();
         ValidationResponseBuilder validationResponsebuilder = new ValidationResponseBuilder(chemical,
                 response2, strategy);
@@ -141,7 +140,7 @@ public class BasicNameValidatorTest extends AbstractSubstanceJpaEntityTest {
                 .build();
         BasicNameValidator validator = new BasicNameValidator();
         validator=AutowireHelper.getInstance().autowireAndProxy(validator);
-        GinasProcessingStrategy strategy = createAcceptApplyAllStrategy();
+        GsrsProcessingStrategy strategy = createAcceptApplyAllStrategy();
         ValidationResponse<Substance> response2 = new ValidationResponse<>();
         ValidationResponseBuilder validationResponsebuilder = new ValidationResponseBuilder(chemical,
                 response2, strategy);
@@ -154,8 +153,8 @@ public class BasicNameValidatorTest extends AbstractSubstanceJpaEntityTest {
     }
 
     //copied from NameEntityService
-    private GinasProcessingStrategy createAcceptApplyAllStrategy() {
-        return new AcceptApplyAllProcessingStrategy(groupService);
+    private GsrsProcessingStrategy createAcceptApplyAllStrategy() {
+        return gsrsProcessingStrategyFactory.createNewDefaultStrategy();
     }
 
 }

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/SubstanceCoreConfiguration.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/SubstanceCoreConfiguration.java
@@ -16,6 +16,7 @@ import gsrs.module.substance.utils.SubstanceMatchViewGenerator;
 import ix.core.search.bulk.BulkSearchService;
 import ix.ginas.utils.validation.ChemicalDuplicateFinder;
 import ix.ginas.utils.validation.strategy.GsrsProcessingStrategyFactory;
+import ix.ginas.utils.validation.strategy.GsrsProcessingStrategyFactoryConfiguration;
 import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
@@ -45,7 +46,8 @@ import org.springframework.context.annotation.Import;
         SubstanceMatchViewGenerator.class,
         SubstanceSequenceFileSupportService.class,
         //used for validation of Substances both single and bulk load
-        GsrsProcessingStrategyFactory.class
+        GsrsProcessingStrategyFactory.class,
+        GsrsProcessingStrategyFactoryConfiguration.class
 })
 public class SubstanceCoreConfiguration {
 

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/CodeEntityService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/CodeEntityService.java
@@ -20,7 +20,7 @@ import ix.core.validator.ValidatorCallback;
 import ix.ginas.models.v1.Code;
 import ix.ginas.models.v1.Reference;
 import ix.ginas.models.v1.Substance;
-import ix.ginas.utils.GinasProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GinasProcessingStrategy;
 import ix.ginas.utils.validation.strategy.AcceptApplyAllProcessingStrategy;
 import ix.utils.Util;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/CodeEntityService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/CodeEntityService.java
@@ -20,8 +20,8 @@ import ix.core.validator.ValidatorCallback;
 import ix.ginas.models.v1.Code;
 import ix.ginas.models.v1.Reference;
 import ix.ginas.models.v1.Substance;
-import ix.ginas.utils.validation.strategy.GinasProcessingStrategy;
-import ix.ginas.utils.validation.strategy.AcceptApplyAllProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GsrsProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GsrsProcessingStrategyFactory;
 import ix.utils.Util;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
@@ -64,6 +64,9 @@ public class CodeEntityService extends AbstractGsrsEntityService<Code, UUID> {
     @Autowired
     private GroupService groupService;
 
+    @Autowired
+    private GsrsProcessingStrategyFactory gsrsProcessingStrategyFactory;
+
     @PersistenceContext(unitName =  DefaultDataSourceConfig.NAME_ENTITY_MANAGER)
     private EntityManager entityManager;
 
@@ -81,13 +84,9 @@ public class CodeEntityService extends AbstractGsrsEntityService<Code, UUID> {
         return UUID.fromString(idAsString);
     }
 
-    private  GinasProcessingStrategy createAcceptApplyAllStrategy() {
-        return new AcceptApplyAllProcessingStrategy(groupService);
-    }
-
     @Override
     protected <T> ValidatorCallback createCallbackFor(T object, ValidationResponse<T> response, ValidatorConfig.METHOD_TYPE type) {
-        GinasProcessingStrategy strategy = createAcceptApplyAllStrategy();
+        GsrsProcessingStrategy strategy = gsrsProcessingStrategyFactory.createNewDefaultStrategy();
         ValidationResponseBuilder<T> builder = new ValidationResponseBuilder<T>(object, response, strategy){
             @Override
             public void complete() {

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/NameEntityService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/NameEntityService.java
@@ -17,7 +17,7 @@ import ix.core.validator.ValidationResponseBuilder;
 import ix.core.validator.ValidatorCallback;
 import ix.ginas.models.v1.Name;
 import ix.ginas.models.v1.Substance;
-import ix.ginas.utils.GinasProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GinasProcessingStrategy;
 import ix.ginas.utils.validation.strategy.AcceptApplyAllProcessingStrategy;
 import ix.utils.Util;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/NameEntityService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/NameEntityService.java
@@ -17,8 +17,8 @@ import ix.core.validator.ValidationResponseBuilder;
 import ix.core.validator.ValidatorCallback;
 import ix.ginas.models.v1.Name;
 import ix.ginas.models.v1.Substance;
-import ix.ginas.utils.validation.strategy.GinasProcessingStrategy;
-import ix.ginas.utils.validation.strategy.AcceptApplyAllProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GsrsProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GsrsProcessingStrategyFactory;
 import ix.utils.Util;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
@@ -54,6 +54,9 @@ public class NameEntityService extends AbstractGsrsEntityService<Name, UUID> {
     @Autowired
     private GroupService groupRepository;
 
+    @Autowired
+    private GsrsProcessingStrategyFactory gsrsProcessingStrategyFactory;
+
 //    @Autowired
 //    private CvSearchService searchService;
 
@@ -68,13 +71,9 @@ public class NameEntityService extends AbstractGsrsEntityService<Name, UUID> {
         return UUID.fromString(idAsString);
     }
 
-    private  GinasProcessingStrategy createAcceptApplyAllStrategy() {
-        return new AcceptApplyAllProcessingStrategy(groupRepository);
-    }
-
     @Override
     protected <T> ValidatorCallback createCallbackFor(T object, ValidationResponse<T> response, ValidatorConfig.METHOD_TYPE type) {
-        GinasProcessingStrategy strategy = createAcceptApplyAllStrategy();
+        GsrsProcessingStrategy strategy = gsrsProcessingStrategyFactory.createNewDefaultStrategy();
         ValidationResponseBuilder<T> builder = new ValidationResponseBuilder<T>(object, response, strategy){
             @Override
             public void complete() {

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/ReferenceEntityService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/ReferenceEntityService.java
@@ -17,7 +17,7 @@ import ix.core.validator.ValidationResponseBuilder;
 import ix.core.validator.ValidatorCallback;
 import ix.ginas.models.v1.Reference;
 import ix.ginas.models.v1.Substance;
-import ix.ginas.utils.GinasProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GinasProcessingStrategy;
 import ix.ginas.utils.validation.strategy.AcceptApplyAllProcessingStrategy;
 import ix.utils.Util;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/ReferenceEntityService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/ReferenceEntityService.java
@@ -17,8 +17,8 @@ import ix.core.validator.ValidationResponseBuilder;
 import ix.core.validator.ValidatorCallback;
 import ix.ginas.models.v1.Reference;
 import ix.ginas.models.v1.Substance;
-import ix.ginas.utils.validation.strategy.GinasProcessingStrategy;
-import ix.ginas.utils.validation.strategy.AcceptApplyAllProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GsrsProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GsrsProcessingStrategyFactory;
 import ix.utils.Util;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
@@ -54,6 +54,9 @@ public class ReferenceEntityService extends AbstractGsrsEntityService<Reference,
     @Autowired
     private GroupService groupRepository;
 
+    @Autowired
+    private GsrsProcessingStrategyFactory gsrsProcessingStrategyFactory;
+
 //    @Autowired
 //    private CvSearchService searchService;
 
@@ -68,13 +71,9 @@ public class ReferenceEntityService extends AbstractGsrsEntityService<Reference,
         return UUID.fromString(idAsString);
     }
 
-    private  GinasProcessingStrategy createAcceptApplyAllStrategy() {
-        return new AcceptApplyAllProcessingStrategy(groupRepository);
-    }
-
     @Override
     protected <T> ValidatorCallback createCallbackFor(T object, ValidationResponse<T> response, ValidatorConfig.METHOD_TYPE type) {
-        GinasProcessingStrategy strategy = createAcceptApplyAllStrategy();
+        GsrsProcessingStrategy strategy = gsrsProcessingStrategyFactory.createNewDefaultStrategy();
         ValidationResponseBuilder<T> builder = new ValidationResponseBuilder<T>(object, response, strategy){
             @Override
             public void complete() {

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/ValidationUtils.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/ValidationUtils.java
@@ -19,7 +19,7 @@ import ix.core.validator.*;
 import ix.ginas.models.GinasAccessReferenceControlled;
 import ix.ginas.models.v1.*;
 import ix.ginas.models.v1.Substance.SubstanceClass;
-import ix.ginas.utils.validation.strategy.GinasProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GsrsProcessingStrategy;
 import ix.ginas.utils.NucleicAcidUtils;
 import java.io.IOException;
 
@@ -77,7 +77,7 @@ public class ValidationUtils {
 	private static <D extends GinasAccessReferenceControlled> void validatePublicReferenced(Substance s,
                                                                                             D data,
                                                                                             List<GinasProcessingMessage> gpm,
-                                                                                            GinasProcessingStrategy strat,
+                                                                                            GsrsProcessingStrategy strat,
                                                                                             Function<D,String> namer) {
 		//If public
 		if(data.getAccess().isEmpty()){
@@ -101,7 +101,7 @@ public class ValidationUtils {
 
 	private static boolean validateReferenced(Substance s,
                                               GinasAccessReferenceControlled data,
-                                              List<GinasProcessingMessage> gpm, GinasProcessingStrategy strat,
+                                              List<GinasProcessingMessage> gpm, GsrsProcessingStrategy strat,
                                               ReferenceAction onemptyref) {
 
 		boolean worked = true;
@@ -258,7 +258,7 @@ public class ValidationUtils {
 
 
 //	private static boolean validateNames(Substance s,
-//                                         List<GinasProcessingMessage> gpm, GinasProcessingStrategy strat) {
+//                                         List<GinasProcessingMessage> gpm, GsrsProcessingStrategy strat) {
 //		boolean preferred = false;
 //		int display = 0;
 //		List<Name> remnames = new ArrayList<Name>();
@@ -428,7 +428,7 @@ public class ValidationUtils {
 //	}
 //
 //	private static boolean validateCodes(Substance s,
-//                                         List<GinasProcessingMessage> gpm, GinasProcessingStrategy strat) {
+//                                         List<GinasProcessingMessage> gpm, GsrsProcessingStrategy strat) {
 //		List<Code> remnames = new ArrayList<Code>();
 //		for (Code cd : s.codes) {
 //			if (cd == null) {
@@ -531,7 +531,7 @@ public class ValidationUtils {
 	}
 
 	private static boolean validateRelationships(Substance s,
-                                                 List<GinasProcessingMessage> gpm, GinasProcessingStrategy strat) {
+                                                 List<GinasProcessingMessage> gpm, GsrsProcessingStrategy strat) {
 		List<Relationship> remnames = new ArrayList<Relationship>();
 		for (Relationship n : s.relationships) {
 			if (isEffectivelyNull(n)) {
@@ -590,7 +590,7 @@ public class ValidationUtils {
 	}
 
 	private static boolean validateNotes(Substance s,
-                                         List<GinasProcessingMessage> gpm, GinasProcessingStrategy strat) {
+                                         List<GinasProcessingMessage> gpm, GsrsProcessingStrategy strat) {
 		List<Note> remnames = new ArrayList<Note>();
 		for (Note n : s.notes) {
 			if (n == null) {
@@ -704,7 +704,7 @@ public class ValidationUtils {
 //	}
 //
 //	private static List<? extends GinasProcessingMessage> validateAndPrepareMixture(
-//            MixtureSubstance cs, GinasProcessingStrategy strat) {
+//            MixtureSubstance cs, GsrsProcessingStrategy strat) {
 //		List<GinasProcessingMessage> gpm = new ArrayList<GinasProcessingMessage>();
 //		if (cs.mixture == null) {
 //			gpm.add(GinasProcessingMessage
@@ -745,7 +745,7 @@ public class ValidationUtils {
 //	}
 //
 //	private static List<? extends GinasProcessingMessage> validateAndPrepareStructurallyDiverse(
-//            StructurallyDiverseSubstance cs, GinasProcessingStrategy strat) {
+//            StructurallyDiverseSubstance cs, GsrsProcessingStrategy strat) {
 //		List<GinasProcessingMessage> gpm = new ArrayList<GinasProcessingMessage>();
 //		if (cs.structurallyDiverse == null) {
 //			gpm.add(GinasProcessingMessage
@@ -795,7 +795,7 @@ public class ValidationUtils {
 //	}
 //
 //	private static List<? extends GinasProcessingMessage> validateAndPrepareSSG1(
-//            SpecifiedSubstanceGroup1Substance cs, GinasProcessingStrategy strat) {
+//            SpecifiedSubstanceGroup1Substance cs, GsrsProcessingStrategy strat) {
 //		List<GinasProcessingMessage> gpm = new ArrayList<GinasProcessingMessage>();
 //		if (cs.specifiedSubstance == null) {
 //			gpm.add(GinasProcessingMessage
@@ -820,7 +820,7 @@ public class ValidationUtils {
 //	}
 //
 //	private static List<? extends GinasProcessingMessage> validateAndPreparePolymer(
-//            PolymerSubstance cs, GinasProcessingStrategy strat) {
+//            PolymerSubstance cs, GsrsProcessingStrategy strat) {
 //		List<GinasProcessingMessage> gpm = new ArrayList<GinasProcessingMessage>();
 //		if (cs.polymer == null) {
 //			gpm.add(GinasProcessingMessage
@@ -1004,7 +1004,7 @@ public class ValidationUtils {
 	}
 
 	private static List<? extends GinasProcessingMessage> validateAndPrepareNa(
-            NucleicAcidSubstance cs, GinasProcessingStrategy strat) {
+            NucleicAcidSubstance cs, GsrsProcessingStrategy strat) {
 		List<GinasProcessingMessage> gpm = new ArrayList<GinasProcessingMessage>();
 		if (cs.nucleicAcid == null) {
 			gpm.add(GinasProcessingMessage
@@ -1056,7 +1056,7 @@ public class ValidationUtils {
 	}
 
 //	private static List<? extends GinasProcessingMessage> validateAndPrepareProtein(
-//            ProteinSubstance cs, ProteinSubstance old, GinasProcessingStrategy strat) {
+//            ProteinSubstance cs, ProteinSubstance old, GsrsProcessingStrategy strat) {
 //
 //		List<GinasProcessingMessage> gpm = new ArrayList<GinasProcessingMessage>();
 //		if (cs.protein == null) {
@@ -1241,7 +1241,7 @@ public class ValidationUtils {
 //	}
 //
 //	public static List<? extends GinasProcessingMessage> validateAndPrepareChemical(
-//            ChemicalSubstance cs, GinasProcessingStrategy strat, boolean includeReferenceCheck) {
+//            ChemicalSubstance cs, GsrsProcessingStrategy strat, boolean includeReferenceCheck) {
 //		List<GinasProcessingMessage> gpm = new ArrayList<GinasProcessingMessage>();
 //		if (cs.structure == null) {
 //			gpm.add(GinasProcessingMessage.ERROR_MESSAGE("Chemical substance must have a chemical structure"));
@@ -1354,7 +1354,7 @@ public class ValidationUtils {
 //
 //	private static List<GinasProcessingMessage> validateChemicalStructure(
 //            GinasChemicalStructure oldstr, Structure newstr,
-//            GinasProcessingStrategy strat) {
+//            GsrsProcessingStrategy strat) {
 //		List<GinasProcessingMessage> gpm = new ArrayList<GinasProcessingMessage>();
 //
 //		String oldhash = null;
@@ -1428,11 +1428,11 @@ public class ValidationUtils {
 
 //	public static class GinasValidationResponseBuilder<T> extends ValidationResponseBuilder<T> {
 //
-//		private final GinasProcessingStrategy _strategy;
+//		private final GsrsProcessingStrategy _strategy;
 //		public GinasValidationResponseBuilder(T o){
-//			this(o, GinasProcessingStrategy.ACCEPT_APPLY_ALL());
+//			this(o, GsrsProcessingStrategy.ACCEPT_APPLY_ALL());
 //		}
-//		public GinasValidationResponseBuilder(T o, GinasProcessingStrategy strategy) {
+//		public GinasValidationResponseBuilder(T o, GsrsProcessingStrategy strategy) {
 //			super(o, strategy);
 //			this._strategy = Objects.requireNonNull(strategy);
 //			boolean allowPossibleDuplicates=false;

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/ValidationUtils.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/ValidationUtils.java
@@ -19,7 +19,7 @@ import ix.core.validator.*;
 import ix.ginas.models.GinasAccessReferenceControlled;
 import ix.ginas.models.v1.*;
 import ix.ginas.models.v1.Substance.SubstanceClass;
-import ix.ginas.utils.GinasProcessingStrategy;
+import ix.ginas.utils.validation.strategy.GinasProcessingStrategy;
 import ix.ginas.utils.NucleicAcidUtils;
 import java.io.IOException;
 

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptAndApplyAllWarningsProcessingStrategy.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptAndApplyAllWarningsProcessingStrategy.java
@@ -3,7 +3,6 @@ package ix.ginas.utils.validation.strategy;
 import gsrs.services.GroupService;
 import ix.core.validator.GinasProcessingMessage;
 import ix.core.validator.ValidationResponse;
-import ix.ginas.utils.GinasProcessingStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptAndApplyAllWarningsProcessingStrategy.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptAndApplyAllWarningsProcessingStrategy.java
@@ -9,12 +9,13 @@ import java.util.List;
 
 public class AcceptAndApplyAllWarningsProcessingStrategy extends GinasProcessingStrategy {
     @Autowired
-    public AcceptAndApplyAllWarningsProcessingStrategy(GroupService groupRepository) {
-        super(groupRepository);
+    public AcceptAndApplyAllWarningsProcessingStrategy(GroupService groupRepository, GsrsProcessingStrategyFactoryConfiguration srsProcessingStrategyFactoryConfiguration) {
+        super(groupRepository, srsProcessingStrategyFactoryConfiguration);
     }
 
     @Override
     public void processMessage(GinasProcessingMessage gpm) {
+        this.overrideMessage(gpm);
         if (gpm.messageType == GinasProcessingMessage.MESSAGE_TYPE.ERROR) {
             gpm.actionType = GinasProcessingMessage.ACTION_TYPE.FAIL;
         } else {

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptAndApplyAllWarningsProcessingStrategy.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptAndApplyAllWarningsProcessingStrategy.java
@@ -7,9 +7,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
-public class AcceptAndApplyAllWarningsProcessingStrategy extends GinasProcessingStrategy {
+public class AcceptAndApplyAllWarningsProcessingStrategy extends AbstractProcessingStrategy {
     @Autowired
-    public AcceptAndApplyAllWarningsProcessingStrategy(GroupService groupRepository, GsrsProcessingStrategyFactoryConfiguration srsProcessingStrategyFactoryConfiguration) {
+    public AcceptAndApplyAllWarningsProcessingStrategy(GroupService groupRepository,
+            GsrsProcessingStrategyFactoryConfiguration srsProcessingStrategyFactoryConfiguration) {
         super(groupRepository, srsProcessingStrategyFactoryConfiguration);
     }
 

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptApplyAllProcessingStrategy.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptApplyAllProcessingStrategy.java
@@ -7,9 +7,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
-public class AcceptApplyAllProcessingStrategy extends GinasProcessingStrategy {
+public class AcceptApplyAllProcessingStrategy extends AbstractProcessingStrategy {
     @Autowired
-    public AcceptApplyAllProcessingStrategy(GroupService groupRepository, GsrsProcessingStrategyFactoryConfiguration srsProcessingStrategyFactoryConfiguration) {
+    public AcceptApplyAllProcessingStrategy(GroupService groupRepository,
+            GsrsProcessingStrategyFactoryConfiguration srsProcessingStrategyFactoryConfiguration) {
         super(groupRepository, srsProcessingStrategyFactoryConfiguration);
     }
 

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptApplyAllProcessingStrategy.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptApplyAllProcessingStrategy.java
@@ -9,12 +9,13 @@ import java.util.List;
 
 public class AcceptApplyAllProcessingStrategy extends GinasProcessingStrategy {
     @Autowired
-    public AcceptApplyAllProcessingStrategy(GroupService groupRepository) {
-        super(groupRepository);
+    public AcceptApplyAllProcessingStrategy(GroupService groupRepository, GsrsProcessingStrategyFactoryConfiguration srsProcessingStrategyFactoryConfiguration) {
+        super(groupRepository, srsProcessingStrategyFactoryConfiguration);
     }
 
     @Override
     public void processMessage(GinasProcessingMessage gpm) {
+        this.overrideMessage(gpm);
         if (gpm.suggestedChange){
             gpm.actionType = GinasProcessingMessage.ACTION_TYPE.APPLY_CHANGE;
         }else{

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptApplyAllProcessingStrategy.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/AcceptApplyAllProcessingStrategy.java
@@ -3,7 +3,6 @@ package ix.ginas.utils.validation.strategy;
 import gsrs.services.GroupService;
 import ix.core.validator.GinasProcessingMessage;
 import ix.core.validator.ValidationResponse;
-import ix.ginas.utils.GinasProcessingStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GinasProcessingStrategy.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GinasProcessingStrategy.java
@@ -6,190 +6,119 @@ import ix.core.validator.GinasProcessingMessage;
 import ix.core.validator.ValidationResponse;
 import ix.ginas.models.v1.Substance;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public abstract class GinasProcessingStrategy implements GsrsProcessingStrategy {
-	public static final String FAILED = "FAILED";
-	public static final String WARNING = "WARNING";
-	public static final String FAIL_REASON = "FAIL_REASON";
+    public static final String FAILED = "FAILED";
+    public static final String WARNING = "WARNING";
+    public static final String FAIL_REASON = "FAIL_REASON";
+    public static enum HANDLING_TYPE {
+        MARK, FAIL, FORCE_IGNORE, NOTE
+    };
+    public HANDLING_TYPE failType = HANDLING_TYPE.MARK;
+    public HANDLING_TYPE warningHandle = HANDLING_TYPE.MARK;
+    //TODO: add messages directly here
+    public List<GinasProcessingMessage> _localMessages = new ArrayList<GinasProcessingMessage>();
 
-	private final GroupService groupRepository;
+    private final GroupService groupRepository;
 
-	public GinasProcessingStrategy(GroupService groupRepository){
-		this.groupRepository = Objects.requireNonNull(groupRepository);
-	}
-	//TODO: add messages directly here
-	public List<GinasProcessingMessage> _localMessages = new ArrayList<GinasProcessingMessage>();
-	@Override
-	public abstract void processMessage(GinasProcessingMessage gpm);
-	@Override
-	public boolean test(GinasProcessingMessage gpm){
-		processMessage(gpm);
-		return gpm.actionType == GinasProcessingMessage.ACTION_TYPE.APPLY_CHANGE;
-	}
-	@Override
-	public void addAndProcess(List<GinasProcessingMessage> source, List<GinasProcessingMessage> destination){
-		for(GinasProcessingMessage gpm: source){
-			this.processMessage(gpm);
-			destination.add(gpm);
-		}
-	}
-	@Override
-	public abstract void setIfValid(ValidationResponse validationResponse,  List<GinasProcessingMessage> messages);
+    public GinasProcessingStrategy(GroupService groupRepository){
+        this.groupRepository = Objects.requireNonNull(groupRepository);
+    }
 
-	public static enum HANDLING_TYPE {
-		MARK, FAIL, FORCE_IGNORE, NOTE
-	};
+    @Override
+    public abstract void processMessage(GinasProcessingMessage gpm);
 
-	public HANDLING_TYPE failType = HANDLING_TYPE.MARK;
-	public HANDLING_TYPE warningHandle = HANDLING_TYPE.MARK;
+    @Override
+    public boolean test(GinasProcessingMessage gpm){
+        processMessage(gpm);
+        return gpm.actionType == GinasProcessingMessage.ACTION_TYPE.APPLY_CHANGE;
+    }
 
-	//TODO katzelda Feb 2021: moved implementations to their own classes so we can inject depdendencies
-//	private static GinasProcessingStrategy _ACCEPT_APPLY_ALL = new GinasProcessingStrategy() {
-//		@Override
-//		public void processMessage(GinasProcessingMessage gpm) {
-//			if (gpm.suggestedChange){
-//				gpm.actionType = GinasProcessingMessage.ACTION_TYPE.APPLY_CHANGE;
-//			}else{
-//				if(gpm.isError()){
-//					gpm.actionType= GinasProcessingMessage.ACTION_TYPE.FAIL;
-//				}else{
-//					gpm.actionType = GinasProcessingMessage.ACTION_TYPE.IGNORE;
-//				}
-//			}
-//		}
-//	};
+    @Override
+    public void addAndProcess(List<GinasProcessingMessage> source, List<GinasProcessingMessage> destination){
+        for(GinasProcessingMessage gpm: source){
+            this.processMessage(gpm);
+            destination.add(gpm);
+        }
+    }
 
-//	private static GinasProcessingStrategy _ACCEPT_APPLY_ALL_WARNINGS = new GinasProcessingStrategy() {
-//		@Override
-//		public void processMessage(GinasProcessingMessage gpm) {
-//			if (gpm.messageType == GinasProcessingMessage.MESSAGE_TYPE.ERROR) {
-//				gpm.actionType = GinasProcessingMessage.ACTION_TYPE.FAIL;
-//			} else {
-//				if (gpm.suggestedChange){
-//					gpm.actionType = GinasProcessingMessage.ACTION_TYPE.APPLY_CHANGE;
-//				}else{
-//					gpm.actionType = GinasProcessingMessage.ACTION_TYPE.IGNORE;
-//				}
-//			}
-//		}
-//	};
-	
-//	public static GinasProcessingStrategy fromValue(String value){
-//		switch(value.toUpperCase()){
-//			case "ACCEPT_APPLY_ALL":
-//				return ACCEPT_APPLY_ALL();
-//			case "ACCEPT_APPLY_ALL_WARNINGS":
-//				return ACCEPT_APPLY_ALL_WARNINGS();
-//			case "ACCEPT_APPLY_ALL_WARNINGS_MARK_FAILED":
-//				return ACCEPT_APPLY_ALL_WARNINGS_MARK_FAILED();
-//			case "ACCEPT_APPLY_ALL_MARK_FAILED":
-//				return ACCEPT_APPLY_ALL_MARK_FAILED();
-//			case "ACCEPT_APPLY_ALL_NOTE_FAILED":
-//				return ACCEPT_APPLY_ALL_NOTE_FAILED();
-//			basic:
-//				throw new IllegalArgumentException("No strategy known with name:\"" + value + "\"");
-//		}
-//
-//	}
+    @Override
+    public abstract void setIfValid(ValidationResponse validationResponse,  List<GinasProcessingMessage> messages);
 
+    @Override
+    public boolean handleMessages(Substance cs, List<GinasProcessingMessage> list) {
+        boolean allow=true;
+        final String noteFailed="Imported record has some validation issues and should not be considered authoratiative at this time";
+        Map<String, Group> cache = new HashMap<>();
+        for (GinasProcessingMessage gpm : list) {
+            //TODO katzelda May 2021 : why was this here?  was this just a combination of different strategies?
+//            if(gpm.isError() && gpm.appliedChange){
+//                gpm.messageType= GinasProcessingMessage.MESSAGE_TYPE.WARNING;
+//            }
 
-//	public static GinasProcessingStrategy ACCEPT_APPLY_ALL() {
-//		return _ACCEPT_APPLY_ALL;
-//	}
-//
-//	public static GinasProcessingStrategy ACCEPT_APPLY_ALL_WARNINGS() {
-//		return _ACCEPT_APPLY_ALL_WARNINGS;
-//	}
-//
-//
-//	public static GinasProcessingStrategy ACCEPT_APPLY_ALL_WARNINGS_MARK_FAILED() {
-//		return ACCEPT_APPLY_ALL_WARNINGS().markFailed();
-//	}
-//
-//	public static GinasProcessingStrategy ACCEPT_APPLY_ALL_WARNINGS_NOTE_FAILED() {
-//		return ACCEPT_APPLY_ALL_WARNINGS().markFailed();
-//	}
-//
-//	public static GinasProcessingStrategy ACCEPT_APPLY_ALL_MARK_FAILED() {
-//		return ACCEPT_APPLY_ALL().markFailed();
-//	}
-//	public static GinasProcessingStrategy ACCEPT_APPLY_ALL_NOTE_FAILED() {
-//		return ACCEPT_APPLY_ALL().noteFailed();
-//	}
-//
+            if (gpm.actionType == GinasProcessingMessage.ACTION_TYPE.FAIL || gpm.isError()) {
 
-	public GinasProcessingStrategy markFailed() {
-		this.failType = HANDLING_TYPE.MARK;
-		return this;
-	}
+                if (failType == HANDLING_TYPE.FAIL) {
+                    throw new IllegalStateException(gpm.message);
 
-	public GinasProcessingStrategy noteFailed() {
-		this.failType = HANDLING_TYPE.NOTE;
-		return this;
-	}
+                } else if (failType == HANDLING_TYPE.MARK) {
+                    cs.status = GinasProcessingStrategy.FAILED;
+                    cs.addRestrictGroup(getGroupByName(Substance.GROUP_ADMIN));
 
-	public GinasProcessingStrategy failFailed() {
-		this.failType = HANDLING_TYPE.FAIL;
-		return this;
-	}
+                } else if (failType == HANDLING_TYPE.NOTE) {
+                    boolean hasNoteYet=cs.getNotes().stream()
+                                                    .filter(n->n.note.equals(noteFailed))
+                                                    .findAny()
+                                                    .isPresent();
+                    if(!hasNoteYet){
+                        cs.addNote(noteFailed);
+                    }
+                }
+            }
+        }
+        return allow;
+    }
 
-	public GinasProcessingStrategy forceIgnoreFailed() {
-		this.failType = HANDLING_TYPE.FORCE_IGNORE;
-		return this;
-	}
+    @Override
+    public void addProblems(Substance cs, List<GinasProcessingMessage> list) {
+        if (warningHandle == HANDLING_TYPE.MARK) {
+            List<GinasProcessingMessage> problems = list.stream()
+                .filter(f->f.isProblem())
+                .collect(Collectors.toList());
+            if(!problems.isEmpty()){
+                Map<String, Group> cache = new HashMap<>();
+                cs.setValidationMessages(problems, n-> getGroupByName(n));
+            }
+        }
+    }
 
-	@Override
-	public boolean handleMessages(Substance cs, List<GinasProcessingMessage> list) {
-		boolean allow=true;
-		final String noteFailed="Imported record has some validation issues and should not be considered authoratiative at this time";
-		Map<String, Group> cache = new HashMap<>();
-		for (GinasProcessingMessage gpm : list) {
-			//TODO katzelda May 2021 : why was this here?  was this just a combination of different strategies?
-//			if(gpm.isError() && gpm.appliedChange){
-//				gpm.messageType= GinasProcessingMessage.MESSAGE_TYPE.WARNING;
-//			}
-			
-			if (gpm.actionType == GinasProcessingMessage.ACTION_TYPE.FAIL || gpm.isError()) {
+    public GinasProcessingStrategy markFailed() {
+        this.failType = HANDLING_TYPE.MARK;
+        return this;
+    }
 
-				if (failType == HANDLING_TYPE.FAIL) {
-					throw new IllegalStateException(gpm.message);
+    public GinasProcessingStrategy noteFailed() {
+        this.failType = HANDLING_TYPE.NOTE;
+        return this;
+    }
 
-				} else if (failType == HANDLING_TYPE.MARK) {
-					cs.status = GinasProcessingStrategy.FAILED;
-					cs.addRestrictGroup(getGroupByName(Substance.GROUP_ADMIN));
+    public GinasProcessingStrategy failFailed() {
+        this.failType = HANDLING_TYPE.FAIL;
+        return this;
+    }
 
-				} else if (failType == HANDLING_TYPE.NOTE) {
-					
-					
-					boolean hasNoteYet=cs.getNotes().stream()
-													.filter(n->n.note.equals(noteFailed))
-													.findAny()
-													.isPresent();
-					if(!hasNoteYet){
-						cs.addNote(noteFailed);
-					}
-				}
-			}
-		}
-		return allow;
-	}
+    public GinasProcessingStrategy forceIgnoreFailed() {
+        this.failType = HANDLING_TYPE.FORCE_IGNORE;
+        return this;
+    }
 
-	private Group getGroupByName(String groupName){
-		return groupRepository.registerIfAbsent(groupName);
-	}
-	@Override
-	public void addProblems(Substance cs, List<GinasProcessingMessage> list) {
-		if (warningHandle == HANDLING_TYPE.MARK) {
-			List<GinasProcessingMessage> problems = list.stream()
-				.filter(f->f.isProblem())
-				.collect(Collectors.toList());
-			if(!problems.isEmpty()){
-				Map<String, Group> cache = new HashMap<>();
-				cs.setValidationMessages(problems, n-> getGroupByName(n));
-			}			
-		}
-	}
-
+    private Group getGroupByName(String groupName){
+        return groupRepository.registerIfAbsent(groupName);
+    }
 }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GinasProcessingStrategy.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GinasProcessingStrategy.java
@@ -89,7 +89,7 @@ public abstract class GinasProcessingStrategy implements GsrsProcessingStrategy 
     public void addProblems(Substance cs, List<GinasProcessingMessage> list) {
         if (warningHandle == HANDLING_TYPE.MARK) {
             List<GinasProcessingMessage> problems = list.stream()
-                .filter(f->f.isProblem())
+                .filter(f->(f.getMessageType().getPriority() < 2))
                 .collect(Collectors.toList());
             if(!problems.isEmpty()){
                 Map<String, Group> cache = new HashMap<>();

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GinasProcessingStrategy.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GinasProcessingStrategy.java
@@ -1,5 +1,6 @@
 package ix.ginas.utils.validation.strategy;
 
+import gsrs.security.GsrsSecurityUtils;
 import gsrs.services.GroupService;
 import ix.core.models.Group;
 import ix.core.validator.GinasProcessingMessage;
@@ -126,9 +127,12 @@ public abstract class GinasProcessingStrategy implements GsrsProcessingStrategy 
 
     public void overrideMessage(GinasProcessingMessage gpm){
         for (GsrsProcessingStrategyFactoryConfiguration.OverrideRule or : gsrsProcessingStrategyFactoryConfiguration.getOverrideRules()) {
-            if (or.getRegex().matcher(gpm.toString()).find()) {
-                if (or.getMessageType() != null && !gpm.messageType.equals(or.getMessageType())) {
+            if ((or.getUserRoles() == null || GsrsSecurityUtils.hasAnyRoles(or.getUserRoles())) && or.getRegex().matcher(gpm.toString()).find()) {
+                if (or.getMessageType() != null) {
                     gpm.messageType = or.getMessageType();
+                }
+                if (or.getSuggestedChange() != null) {
+                    gpm.suggestedChange = or.getSuggestedChange().booleanValue();
                 }
                 break;
             }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GinasProcessingStrategy.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GinasProcessingStrategy.java
@@ -1,11 +1,10 @@
-package ix.ginas.utils;
+package ix.ginas.utils.validation.strategy;
 
 import gsrs.services.GroupService;
 import ix.core.models.Group;
 import ix.core.validator.GinasProcessingMessage;
 import ix.core.validator.ValidationResponse;
 import ix.ginas.models.v1.Substance;
-import ix.ginas.utils.validation.strategy.GsrsProcessingStrategy;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GsrsProcessingStrategyFactory.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GsrsProcessingStrategyFactory.java
@@ -12,16 +12,17 @@ import org.springframework.stereotype.Service;
 public class GsrsProcessingStrategyFactory {
 
     private final GroupService groupService;
-    private final GsrsProcessingStrategyFactoryConfiguration srsProcessingStrategyFactoryConfiguration;
+    private final GsrsProcessingStrategyFactoryConfiguration configuration;
 
     @Autowired
-    public GsrsProcessingStrategyFactory(GroupService groupService, GsrsProcessingStrategyFactoryConfiguration srsProcessingStrategyFactoryConfiguration) {
+    public GsrsProcessingStrategyFactory(GroupService groupService,
+            GsrsProcessingStrategyFactoryConfiguration configuration) {
         this.groupService = groupService;
-        this.srsProcessingStrategyFactoryConfiguration = srsProcessingStrategyFactoryConfiguration;
+        this.configuration = configuration;
     }
 
     public GsrsProcessingStrategy createNewDefaultStrategy(){
-        return createNewStrategy(srsProcessingStrategyFactoryConfiguration.getDefaultStrategy());
+        return createNewStrategy(configuration.getDefaultStrategy());
     }
 
     /**
@@ -34,17 +35,17 @@ public class GsrsProcessingStrategyFactory {
     public GsrsProcessingStrategy createNewStrategy(String strategyName){
         switch(strategyName.toUpperCase()){
             case "ACCEPT_APPLY_ALL":
-                return new AcceptApplyAllProcessingStrategy(groupService, srsProcessingStrategyFactoryConfiguration);
+                return (GsrsProcessingStrategy) new AcceptApplyAllProcessingStrategy(groupService, configuration);
             case "ACCEPT_APPLY_ALL_WARNINGS":
-                return new AcceptAndApplyAllWarningsProcessingStrategy(groupService, srsProcessingStrategyFactoryConfiguration);
+                return (GsrsProcessingStrategy) new AcceptAndApplyAllWarningsProcessingStrategy(groupService, configuration);
             case "ACCEPT_APPLY_ALL_WARNINGS_MARK_FAILED":
-                return new AcceptAndApplyAllWarningsProcessingStrategy(groupService, srsProcessingStrategyFactoryConfiguration)
+                return (GsrsProcessingStrategy) new AcceptAndApplyAllWarningsProcessingStrategy(groupService, configuration)
                             .markFailed();
             case "ACCEPT_APPLY_ALL_MARK_FAILED":
-                return new AcceptApplyAllProcessingStrategy(groupService, srsProcessingStrategyFactoryConfiguration)
+                return (GsrsProcessingStrategy) new AcceptApplyAllProcessingStrategy(groupService, configuration)
                             .markFailed();
             case "ACCEPT_APPLY_ALL_NOTE_FAILED":
-                return new AcceptApplyAllProcessingStrategy(groupService, srsProcessingStrategyFactoryConfiguration)
+                return (GsrsProcessingStrategy) new AcceptApplyAllProcessingStrategy(groupService, configuration)
                             .noteFailed();
             default:
                 throw new IllegalArgumentException("No strategy known with name:\"" + strategyName + "\"");

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GsrsProcessingStrategyFactory.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GsrsProcessingStrategyFactory.java
@@ -12,13 +12,16 @@ import org.springframework.stereotype.Service;
 public class GsrsProcessingStrategyFactory {
 
     private final GroupService groupService;
+    private final GsrsProcessingStrategyFactoryConfiguration srsProcessingStrategyFactoryConfiguration;
 
     @Autowired
-    public GsrsProcessingStrategyFactory(GroupService groupService) {
+    public GsrsProcessingStrategyFactory(GroupService groupService, GsrsProcessingStrategyFactoryConfiguration srsProcessingStrategyFactoryConfiguration) {
         this.groupService = groupService;
+        this.srsProcessingStrategyFactoryConfiguration = srsProcessingStrategyFactoryConfiguration;
     }
+
     public GsrsProcessingStrategy createNewDefaultStrategy(){
-        return new AcceptApplyAllProcessingStrategy(groupService);
+        return createNewStrategy(srsProcessingStrategyFactoryConfiguration.getDefaultStrategy());
     }
 
     /**
@@ -31,17 +34,17 @@ public class GsrsProcessingStrategyFactory {
     public GsrsProcessingStrategy createNewStrategy(String strategyName){
         switch(strategyName.toUpperCase()){
             case "ACCEPT_APPLY_ALL":
-                return new AcceptApplyAllProcessingStrategy(groupService);
+                return new AcceptApplyAllProcessingStrategy(groupService, srsProcessingStrategyFactoryConfiguration);
             case "ACCEPT_APPLY_ALL_WARNINGS":
-                return new AcceptAndApplyAllWarningsProcessingStrategy(groupService);
+                return new AcceptAndApplyAllWarningsProcessingStrategy(groupService, srsProcessingStrategyFactoryConfiguration);
             case "ACCEPT_APPLY_ALL_WARNINGS_MARK_FAILED":
-                return new AcceptAndApplyAllWarningsProcessingStrategy(groupService)
+                return new AcceptAndApplyAllWarningsProcessingStrategy(groupService, srsProcessingStrategyFactoryConfiguration)
                             .markFailed();
             case "ACCEPT_APPLY_ALL_MARK_FAILED":
-                return new AcceptApplyAllProcessingStrategy(groupService)
+                return new AcceptApplyAllProcessingStrategy(groupService, srsProcessingStrategyFactoryConfiguration)
                             .markFailed();
             case "ACCEPT_APPLY_ALL_NOTE_FAILED":
-                return new AcceptApplyAllProcessingStrategy(groupService)
+                return new AcceptApplyAllProcessingStrategy(groupService, srsProcessingStrategyFactoryConfiguration)
                             .noteFailed();
             default:
                 throw new IllegalArgumentException("No strategy known with name:\"" + strategyName + "\"");

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GsrsProcessingStrategyFactoryConfiguration.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GsrsProcessingStrategyFactoryConfiguration.java
@@ -1,10 +1,14 @@
 package ix.ginas.utils.validation.strategy;
 
+import ix.core.models.Role;
 import ix.core.validator.GinasProcessingMessage;
+
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import lombok.Data;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -20,7 +24,8 @@ public class GsrsProcessingStrategyFactoryConfiguration {
     @Data
     public static class OverrideRule {
         private Pattern regex;
-        private GinasProcessingMessage.ACTION_TYPE actionType;
         private GinasProcessingMessage.MESSAGE_TYPE messageType;
+        private List<Role> userRoles;
+        private Boolean suggestedChange;
     }
 }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GsrsProcessingStrategyFactoryConfiguration.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GsrsProcessingStrategyFactoryConfiguration.java
@@ -1,0 +1,26 @@
+package ix.ginas.utils.validation.strategy;
+
+import ix.core.validator.GinasProcessingMessage;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties("gsrs.processing-strategy")
+public class GsrsProcessingStrategyFactoryConfiguration {
+    private String defaultStrategy;
+    private List<OverrideRule> overrideRules;
+
+    @Data
+    public static class OverrideRule {
+        private Pattern regex;
+        private GinasProcessingMessage.ACTION_TYPE actionType;
+        private GinasProcessingMessage.MESSAGE_TYPE messageType;
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GsrsProcessingStrategyFactoryConfiguration.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/strategy/GsrsProcessingStrategyFactoryConfiguration.java
@@ -24,8 +24,7 @@ public class GsrsProcessingStrategyFactoryConfiguration {
     @Data
     public static class OverrideRule {
         private Pattern regex;
-        private GinasProcessingMessage.MESSAGE_TYPE messageType;
+        private GinasProcessingMessage.MESSAGE_TYPE newMessageType;
         private List<Role> userRoles;
-        private Boolean suggestedChange;
     }
 }


### PR DESCRIPTION
This PR adds GsrsProcessingStrategyFactoryConfiguration module. This allows to set default validation processing strategy and override some properties of GinasProcessingMessage object based on the 'regex'.

Configuration example:
```
gsrs.processing-strategy = {
    "defaultStrategy": "ACCEPT_APPLY_ALL",
    "overrideRules": [
        {"regex": "W.*", "userRoles": ["Approver","Admin"], "newMessageType": "NOTICE"}
    ]
}
```

This PR depends on https://github.com/ncats/gsrs-spring-starter/pull/139
