### PR TITLE
WIP: Fix ez rings

### DIFF
--- a/gsrs-module-substances-core/src/main/java/ix/core/chem/StructureProcessor.java
+++ b/gsrs-module-substances-core/src/main/java/ix/core/chem/StructureProcessor.java
@@ -215,7 +215,7 @@ public class StructureProcessor {
         }
 
         
-        Map<Integer,Integer> ringsize= ChemUtils.getSmallestRingSizeForEachBond(mol, 9);
+        CachedSupplier<Map<Integer,Integer>> ringsizeMaker= CachedSupplier.of(()->ChemUtils.getSmallestRingSizeForEachBond(mol, 9));
         
 
         for(DoubleBondStereochemistry doubleBondStereochemistry : mol.getDoubleBondStereochemistry()) {
@@ -231,9 +231,11 @@ public class StructureProcessor {
         			//
         			// Note: this is still a simplification as there are other geometric effects which 
         			// can still make some double bonds ineligible for both E and Z.
-        			int smallestRing= ringsize.getOrDefault(mol.indexOf(doubleBond),999);
-        			if(smallestRing<8) {
-        				isRing=true;
+        			if(doubleBond.isInRing()) {
+	        			int smallestRing= ringsizeMaker.get().getOrDefault(mol.indexOf(doubleBond),999);
+	        			if(smallestRing<8) {
+	        				isRing=true;
+	        			}
         			}
         		}catch(Exception e){
         			log.warn("Trouble detecting ring geometry for EZ calculation");

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/ChemUtils.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/ChemUtils.java
@@ -1,6 +1,20 @@
 package ix.ginas.utils;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import gov.nih.ncats.molwitch.Atom;
+import gov.nih.ncats.molwitch.Bond;
 import gov.nih.ncats.molwitch.Chemical;
 import ix.core.models.Structure;
 import ix.core.models.Structure.Optical;
@@ -9,12 +23,6 @@ import ix.core.validator.GinasProcessingMessage;
 import ix.core.validator.ValidatorCallback;
 import ix.utils.FortranLikeParserHelper.LineParser;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Slf4j
 public class ChemUtils {
@@ -162,5 +170,198 @@ public class ChemUtils {
 			}
 			callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE(messageText.toString()));
 		}
+	}
+	
+	
+	
+	public static List<Bond> getNeighborBonds(Chemical c, Bond cb){
+		List<Bond> bonds = new ArrayList<>();
+		
+		
+		for(Atom at:streamAtoms(cb).collect(Collectors.toList())){
+			at.getBonds()
+			  .forEach(cbb->{
+				  if(!cbb.equals(cb)){
+					  bonds.add(cbb);
+				  }
+			  });
+		}
+		return bonds;
+	}
+	
+	private static Stream<Atom> streamAtoms(Bond cb){
+		return Stream.of(cb.getAtom1(),cb.getAtom2());
+	}
+	/**
+	 * This is a ring-detection algorithm which colors edges based on their smallest detected ring, up to the maxRingSize
+	 * specified. This is accomplished with a breadth-first search from each bond
+	 * @param b
+	 * @param m
+	 * @return
+	 */
+	public static Map<Integer,Integer> getSmallestRingSizeForEachBond(Chemical b, int maxRingSize){
+
+		//The computed return object
+		Map<Integer,Integer> minRingForBond= new HashMap<>();
+		
+		// The neighbor bonds "adjacency" type map. Each bond points
+		// to the set of bonds it shares an atom with
+		Map<Integer,BitSet> nbonds= new HashMap<>();
+		
+		
+		// Lookups to go from a bond or atom to its index
+		// with some effort these could be eliminated
+		Map<Bond, Integer> bondIndex = new HashMap<>();
+		Map<Atom, Integer> atomIndex = new HashMap<>();
+		
+		//Cursor Bonds (left and right)
+		Map<Integer,Set<Integer>> cursorBondsL= new HashMap<>();
+		Map<Integer,Set<Integer>> cursorBondsR= new HashMap<>();
+		
+		//Cursor Atoms (left and right)
+		Map<Integer,Set<Integer>> cursorAtomsL= new HashMap<>();
+		Map<Integer,Set<Integer>> cursorAtomsR= new HashMap<>();
+		Map<Integer,Set<Integer>> previousBondsL= new HashMap<>();
+		Map<Integer,Set<Integer>> previousBondsR= new HashMap<>();
+		Map<Integer,Set<Integer>> previousAtomsL= new HashMap<>();
+		Map<Integer,Set<Integer>> previousAtomsR= new HashMap<>();
+		
+		
+		for(int i=0;i<b.getAtomCount();i++){
+			atomIndex.put(b.getAtom(i), i);
+		}
+		for(int i=0;i<b.getBondCount();i++){
+			Bond cb=b.getBond(i);
+			bondIndex.put(cb, i);
+		}
+		for(int i=0;i<b.getBondCount();i++){
+			Bond cb=b.getBond(i);
+//			if(cb.isRingBond()){
+				previousBondsL.put(i,  Stream.of(i).collect(Collectors.toSet()));
+				previousBondsR.put(i,  Stream.of(i).collect(Collectors.toSet()));
+				
+				previousAtomsL.put(i,  Stream.of(atomIndex.get(cb.getAtom1())).collect(Collectors.toSet()));
+				previousAtomsR.put(i,  Stream.of(atomIndex.get(cb.getAtom2())).collect(Collectors.toSet()));
+				
+				cursorBondsL.put(i, cb.getAtom1().getBonds().stream().filter(bbb->!bbb.equals(cb)).map(cbb->bondIndex.get(cbb)).collect(Collectors.toSet()));
+				cursorBondsR.put(i, cb.getAtom2().getBonds().stream().filter(bbb->!bbb.equals(cb)).map(cbb->bondIndex.get(cbb)).collect(Collectors.toSet()));
+				
+				Set<Integer> patsl= previousAtomsL.get(i);
+				Set<Integer> patsr= previousAtomsR.get(i);
+				
+				cursorAtomsL.put(i, cursorBondsL.get(i).stream()
+						                               .flatMap(bbi->streamAtoms(b.getBond(bbi)))
+						                               .map(at->atomIndex.get(at))
+						                               .filter(ati->!patsl.contains(ati))
+						                               .collect(Collectors.toSet())
+						                               );
+				cursorAtomsR.put(i, cursorBondsR.get(i).stream()
+                        .flatMap(bbi->streamAtoms(b.getBond(bbi)))
+                        .map(at->atomIndex.get(at))
+                        .filter(ati->!patsr.contains(ati))
+                        .collect(Collectors.toSet())
+                        );
+//			}
+		}
+		for(int i=0;i<b.getBondCount();i++){
+			Bond cb=b.getBond(i);
+			BitSet bsBond=new BitSet(b.getBondCount());
+			getNeighborBonds(b, cb)
+				.stream()
+				.map(cbb-> bondIndex.get(cbb))
+				.filter(Objects::nonNull)
+				.forEach(ii->{
+					bsBond.set(ii);
+				});
+			nbonds.put(i,bsBond);
+		}
+		int[] cii= new int[]{0,0};
+		int maxIter = (int) Math.ceil((maxRingSize-3)*0.5);
+		for(int iter=0;iter<=maxIter;iter++){
+			cii[1]=iter;
+			for(int i=0;i<b.getBondCount();i++){
+				cii[0]=i;
+
+				Set<Integer> cbl= cursorBondsL.get(i);
+				Set<Integer> cbr= cursorBondsR.get(i);
+				Set<Integer> casl= cursorAtomsL.get(i);
+				Set<Integer> casr= cursorAtomsR.get(i);
+				
+				if(minRingForBond.get(i)==null && cbl!=null && cbr!=null){
+					boolean ringBonds= cbl.stream().filter(cali->cbr.contains(cali)).findAny().isPresent();
+					if(ringBonds){
+						minRingForBond.put(i, iter*2+2);
+						continue;
+					}
+					if(iter*2+3<=maxRingSize){
+						boolean ringatoms= casl.stream().filter(cali->casr.contains(cali)).findAny().isPresent();
+						if(ringatoms){
+							minRingForBond.put(i, iter*2+3); //iter*2+3 = maxRing  iter=(maxRing-3)/2
+							continue;
+						}
+					}
+					
+					Set<Integer> pbr= previousBondsR.computeIfAbsent(i, k->{
+						return new HashSet<>();
+					});
+					Set<Integer> pbl= previousBondsL.computeIfAbsent(i, k->{
+						return new HashSet<>();
+					});
+					Set<Integer> par= previousAtomsR.computeIfAbsent(i, k->{
+						return new HashSet<>();
+					});
+					Set<Integer> pal= previousAtomsL.computeIfAbsent(i, k->{
+						return new HashSet<>();
+					});
+					Set<Integer> newCursorR = new HashSet<>();
+					Set<Integer> newCursorL = new HashSet<>();
+					Set<Integer> newAtomsR  = new HashSet<>();
+					Set<Integer> newAtomsL  = new HashSet<>();
+					
+					cbl.stream()
+					  .flatMap(j->nbonds.get(j).stream().mapToObj(ib->(Integer)ib))
+					  .filter(bi->!pbl.contains(bi))
+					  .filter(bi->!cbl.contains(bi))
+					  .forEach(ii->{
+						  newCursorL.add(ii);
+					  });
+					cbr.stream()
+					  .flatMap(j->nbonds.get(j).stream().mapToObj(ib->(Integer)ib))
+					  .filter(bi->!pbr.contains(bi))
+					  .filter(bi->!cbl.contains(bi))
+					  .forEach(ii->{
+						  newCursorR.add(ii);
+					  });
+					
+					newCursorL.stream()
+					         .flatMap(ii->streamAtoms(b.getBond(ii)))
+					         .map(ca->atomIndex.get(ca))
+					         .filter(ii->!casl.contains(ii))
+					         .forEach(ii->{
+								  newAtomsL.add(ii);
+							  });
+					newCursorR.stream()
+			         .flatMap(ii->streamAtoms(b.getBond(ii)))
+			         .map(ca->atomIndex.get(ca))
+			         .filter(ii->!casr.contains(ii))
+			         .forEach(ii->{
+						  newAtomsR.add(ii);
+					  });
+					         
+					pbr.addAll(cbr);
+					pbl.addAll(cbl);
+					par.addAll(casr);
+					pal.addAll(casl);
+					
+					cursorBondsR.put(i,newCursorR);
+					cursorBondsL.put(i,newCursorL);
+					cursorAtomsR.put(i,newAtomsR);
+					cursorAtomsL.put(i,newAtomsL);
+					
+				}
+			}
+		}
+		
+		return minRingForBond;
 	}
 }


### PR DESCRIPTION
Currently we prevent ring double bonds from ever being considered EZ centers. That's a mistake that crept in from the switchover to abstract toolkits. Should consider any ring 8 or larger to have the double bonds be potential EZ centers. This code does this without going deep into molwitch to make those changes part of the library.