### PR TITLE
(See #233 instead) Simplify the CodeSequentialGenerator

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/substance/processor/UniqueCodeGeneratorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/processor/UniqueCodeGeneratorTest.java
@@ -95,7 +95,8 @@ public class UniqueCodeGeneratorTest extends AbstractSubstanceJpaEntityTest {
         String suffix = "SUFFIX";
         boolean padding = true;
         String codeSystem = "Codes R Us";
-        CodeSequentialGenerator codeGenerator = new CodeSequentialGenerator(seqGenName, length, suffix, padding, codeSystem);//removed 'last'
+        Long max = Long.MAX_VALUE;
+        CodeSequentialGenerator codeGenerator = new CodeSequentialGenerator(seqGenName, length, suffix, padding, max, codeSystem);
         ProteinSubstance substance = getSubstanceFromFile("YYD6UT8T47");
         AutowireHelper.getInstance().autowire(codeGenerator);
         codeGenerator.addCode(substance);
@@ -110,6 +111,7 @@ public class UniqueCodeGeneratorTest extends AbstractSubstanceJpaEntityTest {
         instantiationMap.put("length", 9);
         instantiationMap.put("codesystem", codeSystemName);
         instantiationMap.put("padding", true);
+        instantiationMap.put("max", Long.MAX_VALUE);
         UniqueCodeGenerator uniqueCodeGenerator = new UniqueCodeGenerator(instantiationMap);
         AutowireHelper.getInstance().autowire(uniqueCodeGenerator);
 
@@ -144,6 +146,7 @@ public class UniqueCodeGeneratorTest extends AbstractSubstanceJpaEntityTest {
         instantiationMap.put("length", 9);
         instantiationMap.put("codesystem", codeSystemName);
         instantiationMap.put("padding", true);
+        instantiationMap.put("max", Long.MAX_VALUE);
         UniqueCodeGenerator uniqueCodeGenerator = new UniqueCodeGenerator(instantiationMap);
         AutowireHelper.getInstance().autowire(uniqueCodeGenerator);
 
@@ -161,6 +164,7 @@ public class UniqueCodeGeneratorTest extends AbstractSubstanceJpaEntityTest {
         instantiationMap.put("length", 9);
         instantiationMap.put("codesystem", codeSystemName);
         instantiationMap.put("padding", true);
+        instantiationMap.put("max", Long.MAX_VALUE);
         UniqueCodeGenerator uniqueCodeGenerator = new UniqueCodeGenerator(instantiationMap);
         AutowireHelper.getInstance().autowire(uniqueCodeGenerator);
 

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/UniqueCodeGenerator.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/UniqueCodeGenerator.java
@@ -37,15 +37,21 @@ public class UniqueCodeGenerator implements EntityProcessor<Substance> {
         String name = (String) with.get("name");
         codeSystem = (String) with.get("codesystem");
         String codeSystemSuffix = (String) with.get("suffix");
-        //Long last = (Long) with.computeIfPresent("last", (key, val) -> ((Number) val).longValue());
         int length = (Integer) with.get("length");
         boolean padding = (Boolean) with.get("padding");
-        String msg = String.format("codeSystem: %s; codeSystemSuffix: %s; length: %d;  padding: %b",
-                codeSystem, codeSystemSuffix, length, padding);
+        Long maxValue;
+        try {
+            maxValue = Long.parseLong(String.valueOf(with.get("max")));
+        } catch (Exception e) {
+            maxValue = Long.MAX_VALUE;
+        }
+        final Long max = maxValue;
+        String msg = String.format("codeSystem: %s; codeSystemSuffix: %s; length: %d;  padding: %b, max: %d",
+                codeSystem, codeSystemSuffix, length, padding, max);
         log.trace(msg);
         if (codeSystem != null) {
             seqGen = CachedSupplier.runOnce(()->{
-                CodeSequentialGenerator gen= new CodeSequentialGenerator(name, length, codeSystemSuffix, padding, codeSystem);//removed 'last'
+                CodeSequentialGenerator gen= new CodeSequentialGenerator(name, length, codeSystemSuffix, padding, max, codeSystem);
                 return AutowireHelper.getInstance().autowireAndProxy(gen);
 
             });
@@ -110,7 +116,7 @@ public class UniqueCodeGenerator implements EntityProcessor<Substance> {
 
     private void addCodeSystemIfNecessary() {
         log.trace("starting addCodeSystemIfNecessary. cvDomain: " + CODE_SYSTEM_VOCABULARY + "; codeSystem: " + codeSystem);
-        
+
         try {
             Optional<GsrsCodeSystemControlledVocabularyDTO> opt = cvApi.findByDomain(CODE_SYSTEM_VOCABULARY);
 

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/repository/CodeRepository.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/repository/CodeRepository.java
@@ -5,6 +5,7 @@ import ix.ginas.models.v1.Code;
 import ix.ginas.models.v1.Name;
 import ix.ginas.models.v1.Substance;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,9 @@ public interface CodeRepository extends GsrsVersionedRepository<Code, UUID> {
     Stream<String> findCodeByCodeSystemAndCodeLike(String codesystem, String codeLike);
 
     Stream<Code> findCodesByCodeSystemAndCodeLike(String codesystem, String codeLike);
+
+    @Query("select max(CAST(SUBSTRING(c.code, 1, LENGTH(c.code) - LENGTH(:codelike) + 1) as long)) from Code c where c.codeSystem = :codesystem and c.code like :codelike and CAST(SUBSTRING(c.code, 1, LENGTH(c.code) - LENGTH(:codelike) + 1) as long) <= :maxcode")
+    Long findMaxCodeByCodeSystemAndCodeLikeAndCodeLessThen(@Param("codesystem") String codeSystem, @Param("codelike") String codeLike, @Param("maxcode") Long maxCode);
 
     //hibernate query will not convert uuid into a string so we have to concatenate it with empty string for this to work.
     @Query("select s from Name s where CONCAT(s.uuid, '') like ?1%")


### PR DESCRIPTION
This PR simplifies the CodeSequentialGenerator and adds the 'max' parameter to the UniqueCodeGenerator processor. The latest available code for specified CodeSystem and Suffix will be returned directly from the CodeRepsitory.