### PR TITLE
(See #233 instead) Suffix for the CodeSystemGenerator

### DIFF
--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/CodeSystemGenerator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/CodeSystemGenerator.java
@@ -9,16 +9,61 @@ public class CodeSystemGenerator implements NamedIdGenerator<Substance, String>,
 
     private final String name;
     private final String codeSystem;
+    private final String suffix;
+
     @JsonCreator
-    public CodeSystemGenerator(@JsonProperty("name") String name,
-                                @JsonProperty("codeSystem") String codeSystem){
+    public CodeSystemGenerator( @JsonProperty("name") String name,
+                                @JsonProperty("codeSystem") String codeSystem,
+                                @JsonProperty("suffix") String suffix) {
         this.name = name;
         this.codeSystem = codeSystem;
+        this.suffix = suffix;
     }
+
+    private static String modulo10(String candidate) {
+        String clean = candidate.trim().replace("-", "") + "0";
+        char[] chars = clean.toCharArray();
+        if (chars.length == 0) {
+            return "";
+        }
+        for (char c : chars) {
+            if (!Character.isDigit(c)) {
+                return "";
+            }
+        }
+        int sum = 0;
+        for (int i = chars.length-1; i >0; i--) {
+            int position = chars.length-i;
+            sum += (position * Character.getNumericValue(chars[i-1]));
+        }
+        return String.valueOf(sum % 10);
+    }
+
+    private static String modulo11(String candidate) {
+        String clean = candidate.trim().replace("-", "");
+        char[] chars = clean.toCharArray();
+        if (chars.length == 0) {
+            return "";
+        }
+        for (char c : chars) {
+            if (!Character.isDigit(c)) {
+                return "";
+            }
+        }
+        int sum = 0;
+        for (int i = 0; i < chars.length; i++){
+            sum += ((i + 2) * Character.getNumericValue(chars[i]));
+        }
+        return String.valueOf((sum % 11) % 10);
+    }
+
     @Override
     public synchronized String generateId(Substance s) {
         String code = s.codes.stream().filter(c -> (codeSystem.equals(c.codeSystem) && "PRIMARY".equals(c.type))).findFirst()
             .map(c -> c.getCode()).orElse("");
+        if (suffix != null) {
+            code = code + suffix.replace("{{mod10}}", modulo10(code)).replace("{{mod11}}", modulo11(code));
+        }
         return code;
     }
 


### PR DESCRIPTION
This PR adds the 'suffix' property to the CodeSystemGenerator ApprovalID generator. THe 'suffix' can include the '{{mod10}}' and the '{{mod11}}' variable.

Example:
if the 'suffix' = '-{{mod10}}' and the code = '7732-18', then ApprovalID will be '7732-18-5'.
