### PR TITLE
New xfer

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/imports/StagingAreaServiceTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/imports/StagingAreaServiceTest.java
@@ -1,6 +1,8 @@
 package example.imports;
 
+import gsrs.GsrsFactoryConfiguration;
 import gsrs.dataexchange.SubstanceStagingAreaEntityService;
+import gsrs.dataexchange.extractors.*;
 import gsrs.stagingarea.model.MatchableKeyValueTuple;
 import gsrs.stagingarea.service.DefaultStagingAreaService;
 import gsrs.stagingarea.service.StagingAreaService;
@@ -13,10 +15,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 public class StagingAreaServiceTest extends AbstractSubstanceJpaEntityTest {
@@ -26,13 +28,46 @@ public class StagingAreaServiceTest extends AbstractSubstanceJpaEntityTest {
     String substanceContext = "ix.ginas.models.v1.Substance";
 
     @BeforeEach
-    public void setup(){
+    public void setup() throws NoSuchFieldException, IllegalAccessException {
         if( stagingAreaService == null ){
             log.trace("setting up staging area service");
             stagingAreaService = new DefaultStagingAreaService();
             stagingAreaService = AutowireHelper.getInstance().autowireAndProxy(stagingAreaService);
+            Map<String, List<Map<String, Object>>> matchableCalculatorConfig = new HashMap<>();
+            List<Map<String, Object>> configs = new ArrayList<>();
+            Map<String, Object> casExtractor = new HashMap<>();
+            casExtractor.put("matchableCalculationClass", CASNumberMatchableExtractor.class);
+            LinkedHashMap<String, Object> config= new LinkedHashMap<>();
+            config.put("casCodeSystems", Arrays.asList("CAS", "CASNo", "CASNumber"));
+            casExtractor.put("config", config);
+            configs.add(casExtractor);
+
+            Map<String, Object> namesExtractor = new HashMap<>();
+            namesExtractor.put("matchableCalculationClass", AllNamesMatchableExtractor.class);
+            configs.add(namesExtractor);
+
+            Map<String, Object> defHashExtractor = new HashMap<>();
+            defHashExtractor.put("matchableCalculationClass", DefinitionalHashMatchableExtractor.class);
+            configs.add(defHashExtractor);
+
+            Map<String, Object> selectedCodesExtractor = new HashMap<>();
+            selectedCodesExtractor.put("matchableCalculationClass", SelectedCodesMatchableExtractor.class);
+            LinkedHashMap<String, Object> config2= new LinkedHashMap<>();
+            config2.put("codeSystems", Arrays.asList("CAS", "ChemBL", "NCI", "NSC", "EINECS"));
+            selectedCodesExtractor.put("config", config2);
+            configs.add(selectedCodesExtractor);
+
+            Map<String, Object> uuidExtractor = new HashMap<>();
+            uuidExtractor.put("matchableCalculationClass", UUIDMatchableExtractor.class);
+            configs.add(uuidExtractor);
+            matchableCalculatorConfig.put("substances", configs);
+
             SubstanceStagingAreaEntityService stagingAreaEntityService = new SubstanceStagingAreaEntityService();
             stagingAreaEntityService = AutowireHelper.getInstance().autowireAndProxy(stagingAreaEntityService);
+            Field factoryConfigField= stagingAreaEntityService.getClass().getDeclaredField("gsrsFactoryConfiguration");
+            factoryConfigField.setAccessible(true);
+            GsrsFactoryConfiguration factoryConfiguration= (GsrsFactoryConfiguration) factoryConfigField.get(stagingAreaEntityService);
+            factoryConfiguration.setMatchableCalculators(matchableCalculatorConfig);
             stagingAreaService.registerEntityService(stagingAreaEntityService);
         }
     }

--- a/gsrs-module-substances-core/src/main/resources/substances-core.conf
+++ b/gsrs-module-substances-core/src/main/resources/substances-core.conf
@@ -407,7 +407,7 @@ gsrs.entityProcessors=[
 "entityClassName" = "ix.ginas.models.v1.Substance",
 "processor" = "gsrs.module.substance.processors.RelationshipProcessor"
 },
- 
+
 #{
 #	"entityClassName" = "ix.ginas.models.v1.Substance",
 #	"processor" = "gsrs.module.substance.processors.ApprovalIdProcessor"

--- a/gsrs-module-substances-data-exchange/src/main/java/gsrs/dataexchange/SubstanceStagingAreaEntityService.java
+++ b/gsrs-module-substances-data-exchange/src/main/java/gsrs/dataexchange/SubstanceStagingAreaEntityService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import gov.nih.ncats.common.util.CachedSupplier;
 import gov.nih.ncats.common.util.CachedSupplierGroup;
+import gsrs.GsrsFactoryConfiguration;
 import gsrs.dataexchange.extractors.ExplicitMatchableExtractorFactory;
 import gsrs.events.ReindexEntityEvent;
 import gsrs.module.substance.standardizer.SubstanceSynchronizer;
@@ -53,6 +54,9 @@ public class SubstanceStagingAreaEntityService implements StagingAreaEntityServi
 
     @Autowired
     SubstanceSynchronizer substanceSynchronizer;
+
+    @Autowired
+    private GsrsFactoryConfiguration gsrsFactoryConfiguration;
 
     @Override
     public Class<Substance> getEntityClass() {
@@ -141,7 +145,8 @@ public class SubstanceStagingAreaEntityService implements StagingAreaEntityServi
         }
         List<MatchableKeyValueTuple> allMatchables = new ArrayList<>();
         ExplicitMatchableExtractorFactory factory = new ExplicitMatchableExtractorFactory();
-        AutowireHelper.getInstance().autowire(factory);
+        factory.setGsrsFactoryConfiguration(gsrsFactoryConfiguration);
+        factory=AutowireHelper.getInstance().autowireAndProxy(factory);
         factory.createExtractorFor(Substance.class).extract(substance, allMatchables::add);
         return allMatchables;
     }

--- a/gsrs-module-substances-data-exchange/src/main/java/gsrs/dataexchange/extractors/ExplicitMatchableExtractorFactory.java
+++ b/gsrs-module-substances-data-exchange/src/main/java/gsrs/dataexchange/extractors/ExplicitMatchableExtractorFactory.java
@@ -15,7 +15,14 @@ public class ExplicitMatchableExtractorFactory implements MatchableExtractorFact
 
     final String substancesContext = "substances";
 
-    @Autowired
+    public GsrsFactoryConfiguration getGsrsFactoryConfiguration() {
+        return gsrsFactoryConfiguration;
+    }
+
+    public void setGsrsFactoryConfiguration(GsrsFactoryConfiguration gsrsFactoryConfiguration) {
+        this.gsrsFactoryConfiguration = gsrsFactoryConfiguration;
+    }
+
     private GsrsFactoryConfiguration gsrsFactoryConfiguration;
 
     private CachedSupplier<MatchableKeyValueTupleExtractor> matchableExtractors =CachedSupplier.of(()->{


### PR DESCRIPTION
Allows staging area index to run without error when you browse the (perhaps empty) staging area **before** running the indexing job.