### PR TITLE
In ChemicalSubstanceDefinitionalElementImpl, instrument structure whe…

### DIFF
--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/definitional/ChemicalSubstanceDefinitionalElementImpl.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/definitional/ChemicalSubstanceDefinitionalElementImpl.java
@@ -1,16 +1,21 @@
 package gsrs.module.substance.definitional;
 
 import gsrs.module.substance.services.DefinitionalElementImplementation;
+import ix.core.chem.StructureProcessor;
 import ix.core.models.Structure;
 import ix.ginas.models.v1.ChemicalSubstance;
 import ix.ginas.models.v1.Moiety;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 @Slf4j
 public class ChemicalSubstanceDefinitionalElementImpl implements DefinitionalElementImplementation {
+
+    @Autowired
+    private StructureProcessor structureProcessor;
 
     private List<String> stereoUsingOpticalActivities = Arrays.asList( "UNKNOWN", "MIXED", "EPIMERIC");
 
@@ -27,6 +32,11 @@ public class ChemicalSubstanceDefinitionalElementImpl implements DefinitionalEle
             //shouldn't happen unless we get invalid submission
             return;
         }
+        if(structure.properties.isEmpty()) {
+            log.trace("instrumented structure");
+            structure = structureProcessor.instrument(chemicalSubstance.getStructure().toChemical(), true);
+        }
+
         log.debug("starting computeDefinitionalElements (ChemicalSubstance)");
         consumer.accept(DefinitionalElement.of("structure.properties.hash1",
                 structure.getStereoInsensitiveHash(), 1));


### PR DESCRIPTION
…n no properties are found

This resolves an issue where whenever you update a chemical substances, there's a warning about the definition changing even though it has NOT changed.