### PR TITLE
Update all validators to support the validation message id generation

### DIFF
--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/ValidationUtils.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/ValidationUtils.java
@@ -91,7 +91,7 @@ public class ValidationUtils {
 
 			if(!hasPublicReference){
 				GinasProcessingMessage mes = GinasProcessingMessage
-						.ERROR_MESSAGE(namer.apply(data) + " needs an unprotected reference marked \"Public Domain\" in order to be made public.");
+						.ERROR_MESSAGE("%s needs an unprotected reference marked \"Public Domain\" in order to be made public.", namer.apply(data));
 				gpm.add(mes);
 				strat.processMessage(mes);
 			}
@@ -115,15 +115,15 @@ public class ValidationUtils {
 			GinasProcessingMessage gpmerr = null;
 			if (onemptyref == ReferenceAction.FAIL) {
 				gpmerr = GinasProcessingMessage.ERROR_MESSAGE(
-						data.toString() + " needs at least 1 reference")
+						"%s needs at least 1 reference", data.toString())
 						.appliableChange(true);
 			} else if (onemptyref == ReferenceAction.WARN) {
 				gpmerr = GinasProcessingMessage.WARNING_MESSAGE(
-						data.toString() + " needs at least 1 reference")
+						"%s needs at least 1 reference", data.toString())
 						.appliableChange(true);
 			} else {
 				gpmerr = GinasProcessingMessage.WARNING_MESSAGE(
-						data.toString() + " needs at least 1 reference")
+						"%s needs at least 1 reference", data.toString())
 						.appliableChange(true);
 			}
 
@@ -142,8 +142,8 @@ public class ValidationUtils {
 			for (Keyword ref : references) {
 				Reference r = s.getReferenceByUUID(ref.getValue());
 				if (r == null) {
-					gpm.add(GinasProcessingMessage.ERROR_MESSAGE("Reference \""
-							+ ref.getValue() + "\" not found on substance."));
+					gpm.add(GinasProcessingMessage.ERROR_MESSAGE("Reference \"%s\" not found on substance.",
+							ref.getValue()));
 					worked = false;
 				}
 			}
@@ -169,17 +169,17 @@ public class ValidationUtils {
 			GinasProcessingMessage gpmerr = null;
 			if (onemptyref == ReferenceAction.FAIL) {
 				gpmerr = GinasProcessingMessage.ERROR_MESSAGE(
-						data.toString() + " needs at least 1 reference")
+						"%s needs at least 1 reference", data.toString())
 						.appliableChange(true);
 				worked.set(false);
 			} else if (onemptyref == ReferenceAction.WARN) {
 				gpmerr = GinasProcessingMessage.WARNING_MESSAGE(
-						data.toString() + " needs at least 1 reference")
+						"%s needs at least 1 reference", data.toString())
 						.appliableChange(true);
 				worked.set(false);
 			} else {
 				gpmerr = GinasProcessingMessage.WARNING_MESSAGE(
-						data.toString() + " needs at least 1 reference")
+						"%s needs at least 1 reference", data.toString())
 						.appliableChange(true);
 				worked.set(false);
 			}
@@ -202,12 +202,12 @@ public class ValidationUtils {
 					//GSRS-933 more informative error message if you can find the Reference
 					Reference dbReference = referenceRepository.getOne(UUID.fromString(ref.getValue()));
 					if(dbReference !=null) {
-						callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("Reference  type: \"" + dbReference.docType +
-								"\" citation: \"" + dbReference.citation + "\"  uuid \""
-								+ ref.getValue() + "\" not found on substance."));
+						callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE(
+								"Reference  type: \"%s\" citation: \"%s\"  uuid \"%s\" not found on substance.",
+								dbReference.docType, dbReference.citation, ref.getValue()));
 					}else{
-					callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("Reference \""
-							+ ref.getValue() + "\" not found on substance."));
+					callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("Reference \"%s\" not found on substance.",
+							ref.getValue()));
 					}
 					worked.set(false);
 				}
@@ -1031,8 +1031,8 @@ public class ValidationUtils {
 						.getNumberOfUnspecifiedSugarSites(cs);
 				if (unspSugars != 0) {
 					gpm.add(GinasProcessingMessage
-							.ERROR_MESSAGE("Nucleic Acid substance must have every base specify a sugar fragment. Missing "
-									+ unspSugars + " sites."));
+							.ERROR_MESSAGE("Nucleic Acid substance must have every base specify a sugar fragment. Missing %s sites.",
+									unspSugars));
 				}
 
 				int unspLinkages = NucleicAcidUtils
@@ -1040,8 +1040,8 @@ public class ValidationUtils {
 				//This is meant to say you can't be MISSING a link between 2 sugars in an NA
 				if (unspLinkages >0) {
 					gpm.add(GinasProcessingMessage
-							.ERROR_MESSAGE("Nucleic Acid substance must have every linkage specify a linkage fragment. Missing "
-									+ unspLinkages + " sites."));
+							.ERROR_MESSAGE("Nucleic Acid substance must have every linkage specify a linkage fragment. Missing %s sites.",
+									unspLinkages));
 					//Typically you can't also have an extra link (on the 5' end), but it's allowed
 				}else if(unspLinkages < 0 && unspLinkages >= -cs.nucleicAcid.subunits.size()){
 					gpm.add(GinasProcessingMessage

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/AlternateDefinitionValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/AlternateDefinitionValidator.java
@@ -36,8 +36,8 @@ public class AlternateDefinitionValidator extends AbstractValidatorPlugin<Substa
         } else {
             if (s.relationships.size() > 1) {
                 callback.addMessage(GinasProcessingMessage
-                        .ERROR_MESSAGE("Alternative definitions may only have 1 relationship (to the parent definition), found:"
-                                + s.relationships.size()));
+                        .ERROR_MESSAGE("Alternative definitions may only have 1 relationship (to the parent definition), found:%s",
+                                s.relationships.size()));
             } else {
                 SubstanceReference sr = s.getPrimaryDefinitionReference();
                 if (sr == null) {
@@ -47,26 +47,18 @@ public class AlternateDefinitionValidator extends AbstractValidatorPlugin<Substa
                     Substance subPrimary = substanceRepository.findBySubstanceReference(sr);
                     if (subPrimary == null) {
                         callback.addMessage(GinasProcessingMessage
-                                .ERROR_MESSAGE("Primary definition for '"
-                                        + sr.refPname
-                                        + "' ("
-                                        + sr.refuuid + ") not found"));
+                                .ERROR_MESSAGE("Primary definition for '%s' (%s) not found",
+                                        sr.refPname, sr.refuuid));
                     } else {
                         if (subPrimary.definitionType != Substance.SubstanceDefinitionType.PRIMARY) {
                             callback.addMessage(GinasProcessingMessage
-                                    .ERROR_MESSAGE("Cannot add alternative definition for '"
-                                            + sr.refPname
-                                            + "' ("
-                                            + sr.refuuid
-                                            + "). That definition is not primary."));
+                                    .ERROR_MESSAGE("Cannot add alternative definition for '%s' (%s). That definition is not primary.",
+                                            sr.refPname, sr.refuuid));
                         } else {
                             if (subPrimary.substanceClass == Substance.SubstanceClass.concept) {
                                 callback.addMessage(GinasProcessingMessage
-                                        .ERROR_MESSAGE("Cannot add alternative definition for '"
-                                                + sr.refPname
-                                                + "' ("
-                                                + sr.refuuid
-                                                + "). That definition is not definitional substance record."));
+                                        .ERROR_MESSAGE("Cannot add alternative definition for '%s' (%s). That definition is not definitional substance record.",
+                                                sr.refPname, sr.refuuid));
                             } else {
                              //Everything is okay   
                             }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/AutoGenerateUuidIfNeeded.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/AutoGenerateUuidIfNeeded.java
@@ -15,7 +15,7 @@ public class AutoGenerateUuidIfNeeded extends AbstractValidatorPlugin<Substance>
     public void validate(Substance s, Substance objold, ValidatorCallback callback) {
         if (s.getUuid() == null) {
         	UUID uuid = UUID.randomUUID();
-            callback.addMessage(GinasProcessingMessage.INFO_MESSAGE("Substance has no UUID, will generate uuid:\"" + uuid + "\""),
+            callback.addMessage(GinasProcessingMessage.INFO_MESSAGE("Substance has no UUID, will generate uuid:\"%s\"", uuid),
                     ()->s.setUuid(uuid));
         }
     }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/BasicNameValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/BasicNameValidator.java
@@ -66,8 +66,8 @@ public class BasicNameValidator extends AbstractValidatorPlugin<Substance> {
             log.trace(debugMessage);
 
             if (!minimallyStandardizedName.getResult().equals(n.name) || minimallyStandardizedName.getReplacementNotes().size() > 0) {
-                GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE(String.format("Name %s minimally standardized to %s",
-                        n.name, minimallyStandardizedName.getResult()));
+                GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE("Name %s minimally standardized to %s",
+                        n.name, minimallyStandardizedName.getResult());
                 mes.appliableChange(true);
                 callback.addMessage(mes, () -> {
                     n.name = minimallyStandardizedName.getResult();

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CASCodeValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CASCodeValidator.java
@@ -27,8 +27,7 @@ public class CASCodeValidator extends AbstractValidatorPlugin<Substance> {
             if ("CAS".equals(cd.codeSystem)) {
                 if (performFormatCheck && !CASUtilities.isValidCas(cd.code)) {
                     GinasProcessingMessage mesWarn = GinasProcessingMessage
-                            .WARNING_MESSAGE(
-                                    String.format("CAS Number %s does not have the expected format. (Verify the check digit.)", cd.code));
+                            .WARNING_MESSAGE("CAS Number %s does not have the expected format. (Verify the check digit.)", cd.code);
 
                     callback.addMessage(mesWarn);
                 }
@@ -44,8 +43,7 @@ public class CASCodeValidator extends AbstractValidatorPlugin<Substance> {
                     }
                     if (!found) {
                         GinasProcessingMessage mes = GinasProcessingMessage
-                                .WARNING_MESSAGE(
-                                        "Must specify STN reference for CAS");
+                                .WARNING_MESSAGE("Must specify STN reference for CAS");
 
                         callback.addMessage(mes, () -> {
                             Reference newRef = new Reference();

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CVFragmentStructureValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CVFragmentStructureValidator.java
@@ -46,7 +46,7 @@ public class CVFragmentStructureValidator extends AbstractValidatorPlugin<Contro
 		List<FragmentVocabularyTerm> invalidUpdateTerms =newCV.getTerms().stream()
 				.filter(term-> term instanceof FragmentVocabularyTerm)
 				.map(term->(FragmentVocabularyTerm)term)
-				.filter(term->!Optional.ofNullable(term.getFragmentStructure()).isPresent() 
+				.filter(term->!Optional.ofNullable(term.getFragmentStructure()).isPresent()
 						|| !Optional.ofNullable(term.getDisplay()).isPresent()
 						|| !Optional.ofNullable(term.getValue()).isPresent())
 				.collect(Collectors.toList());
@@ -60,48 +60,48 @@ public class CVFragmentStructureValidator extends AbstractValidatorPlugin<Contro
 		
 		Map<String, List<String>> hashLookup = newCV.getTerms().stream()
 		.filter(term-> term instanceof FragmentVocabularyTerm)
-		.map(key->(FragmentVocabularyTerm)key)		
+		.map(key->(FragmentVocabularyTerm)key)
 		.map(f->Tuple.of(getHash(f), f.getValue()))
 		.filter(t->t.k().isPresent())
 		.map(Tuple.kmap(k->k.get()))
 		.collect(Tuple.toGroupedMap());
-				
-		List<FragmentVocabularyTerm> addedOrUpdatedTerms = new ArrayList<FragmentVocabularyTerm>(); 
+
+		List<FragmentVocabularyTerm> addedOrUpdatedTerms = new ArrayList<FragmentVocabularyTerm>();
 		addedOrUpdatedTerms.addAll(changes.addedTerms);
-		addedOrUpdatedTerms.addAll(changes.updatedTerms);		
-		addedOrUpdatedTerms.forEach(term -> chemicalValidation(term, hashLookup, callback));		
+		addedOrUpdatedTerms.addAll(changes.updatedTerms);
+		addedOrUpdatedTerms.forEach(term -> chemicalValidation(term, hashLookup, callback));
 	}
 	
 		
 	private Optional<String> getHash(FragmentVocabularyTerm term) {
 		try {
-			String inputStructure = term.getFragmentStructure().split(" ")[0];			
-			Chemical chem = Chemical.parse(inputStructure);			
-			chem = Chem.RemoveQueryAtomsForPseudoInChI(chem);			
-			return Optional.of(chem.toInchi().getKey());			
-		} catch (IOException e) {			
+			String inputStructure = term.getFragmentStructure().split(" ")[0];
+			Chemical chem = Chemical.parse(inputStructure);
+			chem = Chem.RemoveQueryAtomsForPseudoInChI(chem);
+			return Optional.of(chem.toInchi().getKey());
+		} catch (IOException e) {
 			e.printStackTrace();
 			return Optional.empty();
-		}		
-	}	
-		
-	private void chemicalValidation(FragmentVocabularyTerm term, Map<String,List<String>> lookup, ValidatorCallback callback) {		
+		}
+	}
+
+	private void chemicalValidation(FragmentVocabularyTerm term, Map<String,List<String>> lookup, ValidatorCallback callback) {
 		
 		String fragmentStructure = term.getFragmentStructure().trim();
 		Chemical chem;
 		try {
-			chem = Chemical.parse(fragmentStructure);				
-		}catch(IOException ex) {	
+			chem = Chemical.parse(fragmentStructure);
+		}catch(IOException ex) {
 			try {
 				chem = Chemical.parse(fragmentStructure.split(" ")[0]);
 				if (!Optional.ofNullable(chem).isPresent()) {
 					callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE(
-							"Illegal chemical structure format: " + term.getFragmentStructure()));
+							"Illegal chemical structure format: %s", term.getFragmentStructure()));
 					return;
 				}
 			}catch(IOException IOEx) {
 				callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE(
-						"Illegal chemical structure format: " + term.getFragmentStructure()));
+						"Illegal chemical structure format: %s", term.getFragmentStructure()));
 				return;
 			}
 		}
@@ -111,30 +111,30 @@ public class CVFragmentStructureValidator extends AbstractValidatorPlugin<Contro
 			smiles = chem.toSmiles();
 			// todo: may need to add warning with applicable change
 			if(!Optional.ofNullable(term.getSimplifiedStructure()).isPresent())
-				term.setSimplifiedStructure(smiles);			    
+				term.setSimplifiedStructure(smiles);
 		} catch (IOException e) {
 			callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE(
-					"Illegal chemical structure format: " + term.getFragmentStructure()));
+					"Illegal chemical structure format: %s", term.getFragmentStructure()));
 			return;
-		}			
+		}
 		
 		Optional<String> hash = getHash(term);
 		if(!hash.isPresent()) {
 			callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE(
-                    "Illegal chemical structure format getting hash: " + term.getFragmentStructure()));
+                    "Illegal chemical structure format getting hash: %s", term.getFragmentStructure()));
 		} else if(lookup.get(hash.get()).size()>1) {
 			callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE(
-                    "This fragment structure appears to have duplicates: " + term.getFragmentStructure()));				
-		}			
+                    "This fragment structure appears to have duplicates: %s", term.getFragmentStructure()));
+		}
 	}	
 	
-	private FragmentChanges getAddedUpdatedDeletedTerms(ControlledVocabulary newCV, ControlledVocabulary oldCV) {	
+	private FragmentChanges getAddedUpdatedDeletedTerms(ControlledVocabulary newCV, ControlledVocabulary oldCV) {
 		
 		FragmentChanges fragmentChanges = new FragmentChanges();
-					
+
 		List<FragmentVocabularyTerm> termsAfterUpdate =newCV.getTerms().stream()
 				.filter(term->term instanceof FragmentVocabularyTerm)
-				.map(term->(FragmentVocabularyTerm)term)			
+				.map(term->(FragmentVocabularyTerm)term)
 				.collect(Collectors.toList());
 		
 		Optional <ControlledVocabulary> oldCVOptional = Optional.ofNullable(oldCV);
@@ -145,9 +145,9 @@ public class CVFragmentStructureValidator extends AbstractValidatorPlugin<Contro
 		
 		List<FragmentVocabularyTerm> termsBeforeUpdate = oldCV.getTerms().stream()
 				.filter(term-> term instanceof FragmentVocabularyTerm)
-				.map(term->(FragmentVocabularyTerm)term)				
+				.map(term->(FragmentVocabularyTerm)term)
 				.collect(Collectors.toList());
-							
+
 		termsAfterUpdate.stream().forEach(term -> {
 				Long id = term.getId();
 				FragmentVocabularyTerm originalTerm = termsBeforeUpdate.stream()
@@ -155,9 +155,9 @@ public class CVFragmentStructureValidator extends AbstractValidatorPlugin<Contro
 					  .findAny()
 					  .orElse(null);
 				if(!Optional.ofNullable(originalTerm).isPresent()) {
-					fragmentChanges.addedTerms.add(term);						
+					fragmentChanges.addedTerms.add(term);
 				}else if(!sameVocabularyTerm(term, originalTerm)) {
-					fragmentChanges.updatedTerms.add(term);					
+					fragmentChanges.updatedTerms.add(term);
 				}});
 		
 		fragmentChanges.deletedTerms = termsBeforeUpdate.stream().filter(term -> {
@@ -170,18 +170,18 @@ public class CVFragmentStructureValidator extends AbstractValidatorPlugin<Contro
 				return true;
 			else
 				return false;
-			}).collect(Collectors.toList());	
+			}).collect(Collectors.toList());
 		
 		return fragmentChanges;
 	}
 	
 	private boolean sameVocabularyTerm(FragmentVocabularyTerm term1, FragmentVocabularyTerm term2) {
 		
-		if( term1.getValue().equalsIgnoreCase(term2.getValue()) 
+		if( term1.getValue().equalsIgnoreCase(term2.getValue())
 			&& term1.getDisplay().equalsIgnoreCase(term2.getDisplay())
 			&& term1.getFragmentStructure().equalsIgnoreCase(term2.getFragmentStructure()))
 			return true;
 		
-		return false;		
+		return false;
 	}
 }	

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/ChemicalUniquenessValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/ChemicalUniquenessValidator.java
@@ -111,7 +111,7 @@ public class ChemicalUniquenessValidator extends AbstractValidatorPlugin<Substan
         results.forEach(r -> {
             Substance duplicate = (Substance) r;
             GinasProcessingMessage message = GinasProcessingMessage.WARNING_MESSAGE(
-                    String.format("Record %s appears to be a duplicate", duplicate.getName()));
+                    "Record %s appears to be a duplicate", duplicate.getName());
             message.addLink(ValidationUtils.createSubstanceLink(duplicate.asSubstanceReference()));
             messages.add(message);
         });

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/ChemicalValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/ChemicalValidator.java
@@ -105,8 +105,7 @@ public class ChemicalValidator extends AbstractValidatorPlugin<Substance> {
                 if (p != null && !p.getSubunits().isEmpty()
                         && p.getSubunits().get(0).getSequence().length() > 2) {
                     GinasProcessingMessage mes = GinasProcessingMessage
-                            .WARNING_MESSAGE("Substance may be represented as protein as well. Sequence:["
-                                    + p.toString() + "]");
+                            .WARNING_MESSAGE("Substance may be represented as protein as well. Sequence:[%s]", p.toString());
                     callback.addMessage(mes);
                 }
             } catch (Exception e) {
@@ -186,7 +185,7 @@ public class ChemicalValidator extends AbstractValidatorPlugin<Substance> {
 //            ChemUtils.checkChargeBalance(cs.structure, gpm);
             if (cs.getStructure().charge != 0) {
                 GinasProcessingMessage mes = GinasProcessingMessage
-                        .WARNING_MESSAGE("Structure is not charged balanced, net charge of: " + cs.getStructure().charge);
+                        .WARNING_MESSAGE("Structure is not charged balanced, net charge of: %s", cs.getStructure().charge);
                 callback.addMessage(mes);
             }
 

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CodeFormatValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CodeFormatValidator.java
@@ -60,7 +60,7 @@ public class CodeFormatValidator extends AbstractValidatorPlugin<Substance>
                         //find ? or matches?
                         if(!matcher.find()){
                             callback.addMessage(GinasProcessingMessage
-                                    .WARNING_MESSAGE(String.format("Code %s does not match pattern %s for system %s", c.getCode(), codeSystemRegex, vt1.getValue())));
+                                    .WARNING_MESSAGE("Code %s does not match pattern %s for system %s", c.getCode(), codeSystemRegex, vt1.getValue()));
                         }
                     }
                 }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CodeUniquenessValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CodeUniquenessValidator.java
@@ -50,11 +50,7 @@ public class CodeUniquenessValidator extends AbstractValidatorPlugin<Substance> 
 
                 if (s2.getUuid() != null && !s2.getUuid().equals(s.getUuid())) {
                     GinasProcessingMessage mes = GinasProcessingMessage
-                            .WARNING_MESSAGE(
-                                    "Code '"
-                                    + cd.code
-                                    + "'[" + cd.codeSystem
-                                    + "] collides (possible duplicate) with existing code & codeSystem for substance:")
+                            .WARNING_MESSAGE("Code '%s'[%s] collides (possible duplicate) with existing code & codeSystem for substance:", cd.code, cd.codeSystem)
                             //                               TODO katelda Feb 2021 : add link support back!
                             .addLink(ValidationUtils.createSubstanceLink(s2.toSubstanceReference()));
                     callback.addMessage(mes);

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CodesValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CodesValidator.java
@@ -54,22 +54,23 @@ public class CodesValidator extends AbstractValidatorPlugin<Substance> {
                 }else if (!(cd.code+"").trim().equals(cd.code+"")) {
                     GinasProcessingMessage mes = GinasProcessingMessage
                             .WARNING_MESSAGE(
-                                    "'Code' '" + cd.code + "' should not have trailing or leading whitespace. Code will be trimmed to '" + cd.code.trim() + "'")
+                                    "'Code' '%s' should not have trailing or leading whitespace. Code will be trimmed to '%s'",
+                                    cd.code, cd.code.trim())
                             .appliableChange(true);
                     callback.addMessage(mes, ()-> cd.code=(cd.code+"").trim());
 
                 }
-                
+
                 if (!ValidationUtils.isEffectivelyNull(cd.codeText) && !(cd.codeText+"").trim().equals(cd.codeText+"")) {
                     GinasProcessingMessage mes = GinasProcessingMessage
                             .WARNING_MESSAGE(
-                                    "'Code comment' '" + cd.codeText + "' should not have trailing or leading whitespace. Code will be trimmed to '" 
-                                            + cd.codeText.trim() + "'")
+                                    "'Code comment' '%s' should not have trailing or leading whitespace. Code will be trimmed to '%s'",
+                                    cd.codeText, cd.codeText.trim())
                             .appliableChange(true);
                     callback.addMessage(mes, ()-> cd.codeText=(cd.codeText+"").trim());
                 }
 
-                
+
             if (ValidationUtils.isEffectivelyNull(cd.codeSystem)) {
                     GinasProcessingMessage mes = GinasProcessingMessage
                             .ERROR_MESSAGE(
@@ -80,8 +81,8 @@ public class CodesValidator extends AbstractValidatorPlugin<Substance> {
                 } else if (!(cd.codeSystem+"").trim().equals(cd.codeSystem+"")) {
                     GinasProcessingMessage mes = GinasProcessingMessage
                             .WARNING_MESSAGE(
-                                    "'Code system' '" + cd.codeSystem + "' should not have trailing or leading whitespace. Code will be trimmed to '" 
-                                            + cd.codeSystem.trim() + "'")
+                                    "'Code system' '%s' should not have trailing or leading whitespace. Code will be trimmed to '%s'",
+                                    cd.codeSystem, cd.codeSystem.trim())
                             .appliableChange(true);
                     callback.addMessage(mes, ()-> cd.codeSystem=(cd.codeSystem+"").trim());
                 }
@@ -106,21 +107,18 @@ public class CodesValidator extends AbstractValidatorPlugin<Substance> {
 //            String debug = String.format("code system: %s, code: %s; comments: %s; type: %s", 
 //                    cd.codeSystem, cd.code, cd.comments, cd.type);
 //            log.trace(debug);
-            
+
             try {
                  if( containsLeadingTrailingSpaces(cd.comments) ) {
                      cd.comments=cd.comments.trim();
                      GinasProcessingMessage mes = GinasProcessingMessage
                                 .WARNING_MESSAGE(
-                                        "Code '"
-                                                + cd.code
-                                                + "'[" +cd.codeSystem
-                                                + "] "
-                                        + "code text: " +  cd.comments  +" contains one or more leading/trailing blanks that will be removed")
+                                        "Code '%s'[%s] code text: %s contains one or more leading/trailing blanks that will be removed",
+                                        cd.code, cd.codeSystem, cd.comments)
                                 .appliableChange(true);
                      callback.addMessage(mes);
                 }
-                
+
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/DEAValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/DEAValidator.java
@@ -30,8 +30,7 @@ public class DEAValidator extends AbstractValidatorPlugin<Substance> {
         String deaSchedule = deaDataTable.getDeaScheduleForChemical(chemical);
         if( deaNumber !=null) {
             GinasProcessingMessage mesWarn = GinasProcessingMessage
-                    .WARNING_MESSAGE(
-                            String.format("This substance has DEA schedule: %s", deaSchedule));
+                    .WARNING_MESSAGE("This substance has DEA schedule: %s", deaSchedule);
             if( deaDataTable.assignCodeForDea(substanceNew, deaNumber)){
                 mesWarn.appliableChange(true);
             }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/DefinitionalDependencyValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/DefinitionalDependencyValidator.java
@@ -52,8 +52,8 @@ public class DefinitionalDependencyValidator extends AbstractValidatorPlugin<Sub
         if( !missing.isEmpty()){
             ValidationResponse<Substance> response= new ValidationResponse<>();
             missing.forEach(i->{
-                ValidationMessage message = GinasProcessingMessage.WARNING_MESSAGE(String.format("Substance %s (ID: %s), listed as %s is missing",
-                                i.getRefPname(), i.getRefuuid(), i.getRole().toLowerCase()));
+                ValidationMessage message = GinasProcessingMessage.WARNING_MESSAGE("Substance %s (ID: %s), listed as %s is missing",
+                                i.getRefPname(), i.getRefuuid(), i.getRole().toLowerCase());
                 response.addValidationMessage(message);
             });
                 return response;

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/DefinitionalHashValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/DefinitionalHashValidator.java
@@ -99,10 +99,9 @@ public class DefinitionalHashValidator  extends AbstractValidatorPlugin<Substanc
 												return;
 										}
 								}
-								String message= createDiffMessage(diff);
-								callback.addMessage(GinasProcessingMessage
-										.WARNING_MESSAGE(message));
-								log.trace("in DefinitionalHashValidator, appending message " + message);
+								GinasProcessingMessage gpm = createDiffMessage(diff);
+								callback.addMessage(gpm);
+								log.trace("in DefinitionalHashValidator, appending message " + gpm.getMessage());
 						} else {
 								log.trace("diffs empty ");
 						}
@@ -122,7 +121,7 @@ public class DefinitionalHashValidator  extends AbstractValidatorPlugin<Substanc
 			return result;
 		}
 		
-		private String createDiffMessage(List<DefinitionalElements.DefinitionalElementDiff> diffs) {
+		private GinasProcessingMessage createDiffMessage(List<DefinitionalElements.DefinitionalElementDiff> diffs) {
 			List<String> messageParts = new ArrayList();
 			for(DefinitionalElements.DefinitionalElementDiff d : diffs){
 				switch(d.getOp()) {
@@ -140,15 +139,11 @@ public class DefinitionalHashValidator  extends AbstractValidatorPlugin<Substanc
 						break;
 				}
 			}
-			String message;
 			if(messageParts.size() == 1) {
-				message ="A definitional change has been made: " +
-					messageParts.get(0) +" please reaffirm.  ";
-			} else {
-				message ="Definitional changes have been made: " +
-					String.join("; ", messageParts) +"; please reaffirm.  ";
+				return GinasProcessingMessage.WARNING_MESSAGE("A definitional change has been made: %s please reaffirm.  ",
+					messageParts.get(0));
 			}
-
-			return message;
+			return GinasProcessingMessage.WARNING_MESSAGE("Definitional changes have been made: %s; please reaffirm.  ",
+				String.join("; ", messageParts));
 		}
 }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/MixtureValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/MixtureValidator.java
@@ -53,16 +53,15 @@ public class MixtureValidator extends AbstractValidatorPlugin<Substance> {
 //                    Substance comp = SubstanceFactory.getFullSubstance(c.substance);
                     if (!substanceRepository.exists(c.substance)) {
                         callback.addMessage(GinasProcessingMessage
-                                .WARNING_MESSAGE("Mixture substance references \""
-                                        + c.substance.getName()
-                                        + "\" which is not yet registered"));
+                                .WARNING_MESSAGE("Mixture substance references \"%s\" which is not yet registered",
+                                        c.substance.getName()));
                     }
                     //add returns false if it's already present so we don't need to do the contains() check before add
                     if (!mixtureIDs.add(c.substance.refuuid)) {
 
                         callback.addMessage(GinasProcessingMessage
-                                .ERROR_MESSAGE("Cannot reference the same mixture substance twice in a mixture:\""
-                                        + c.substance.refPname + "\""));
+                                .ERROR_MESSAGE("Cannot reference the same mixture substance twice in a mixture:\"%s\"",
+                                        c.substance.refPname));
                     }
                 }
 

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NamesValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NamesValidator.java
@@ -144,8 +144,8 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
                 if(!locators.isEmpty()){
                     GinasProcessingMessage mes = GinasProcessingMessage
                             .WARNING_MESSAGE(
-                                    "Names of form \"<NAME> [<TEXT>]\" are transformed to locators. The following locators will be added:"
-                                            + locators.toString())
+                                    "Names of form \"<NAME> [<TEXT>]\" are transformed to locators. The following locators will be added:%s",
+                                            locators.toString())
                             .appliableChange(true);
                     callback.addMessage(mes, ()->{
                         for (String loc : locators) {
@@ -204,7 +204,8 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
 
                 if(!hasPublicReference){
                     GinasProcessingMessage mes = GinasProcessingMessage
-                            .ERROR_MESSAGE("The name :\"" + n.getName() + "\" needs an unprotected reference marked \"Public Domain\" in order to be made public.");
+                            .ERROR_MESSAGE("The name :\"%s\" needs an unprotected reference marked \"Public Domain\" in order to be made public.",
+                                    n.getName());
                     callback.addMessage(mes);
                 }
             }
@@ -220,9 +221,8 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
         }
         if (display == 0) {
             GinasProcessingMessage mes = GinasProcessingMessage
-                    .INFO_MESSAGE(
-                            "Substances should have exactly one (1) display name, Default to using:"
-                                    + s.getName()).appliableChange(true);
+                    .INFO_MESSAGE("Substances should have exactly one (1) display name, Default to using:%s", s.getName())
+                    .appliableChange(true);
             callback.addMessage(mes, () -> {
                 if (!s.names.isEmpty()) {
                     Name.sortNames(s.names);
@@ -233,8 +233,7 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
         }
         if (display > 1) {
             GinasProcessingMessage mes = GinasProcessingMessage
-                    .ERROR_MESSAGE("Substance should not have more than one (1) display name. Found "
-                            + display);
+                    .ERROR_MESSAGE("Substance should not have more than one (1) display name. Found %s", display);
             callback.addMessage(mes);
         }
 
@@ -262,17 +261,11 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
                     log.trace("duplicateNameIsError: {}", duplicateNameIsError);
                     if (duplicateNameIsError) {
                         mes = GinasProcessingMessage
-                                .ERROR_MESSAGE(
-                                        "Name '"
-                                                + name
-                                                + "' is a duplicate name in the record.")
+                                .ERROR_MESSAGE("Name '%s' is a duplicate name in the record.", name)
                                 .markPossibleDuplicate();
                     } else {
                         mes = GinasProcessingMessage
-                                .WARNING_MESSAGE(
-                                        "Name '"
-                                                + name
-                                                + "' is a duplicate name in the record.")
+                                .WARNING_MESSAGE("Name '%s' is a duplicate name in the record.", name)
                                 .markPossibleDuplicate();
                     }
                     callback.addMessage(mes);
@@ -286,10 +279,7 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
                     SubstanceRepository.SubstanceSummary s2 = sr.iterator().next();
                     if (!s2.getUuid().equals(s.getOrGenerateUUID())) {
                         GinasProcessingMessage mes = GinasProcessingMessage
-                                .WARNING_MESSAGE(
-                                        "Name '"
-                                                + n.name
-                                                + "' collides (possible duplicate) with existing name for substance:")
+                                .WARNING_MESSAGE("Name '%s' collides (possible duplicate) with existing name for substance:", n.name)
                                //TODO katzelda Feb 2021: add link back
                                 . addLink(ValidationUtils.createSubstanceLink(s2.toSubstanceReference()))
                                 ;
@@ -303,11 +293,8 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
                 &&  (s.changeReason==null || !s.changeReason.equalsIgnoreCase(CHANGE_REASON_DISPLAYNAME_CHANGED))) {
                 GinasProcessingMessage mes = GinasProcessingMessage
                         .WARNING_MESSAGE(
-                                "Preferred Name has been changed from '"
-                                        + oldDisplayName.get().name
-                                        + "' to '"
-                                        + n.name
-                                        + "'. Please confirm that this change is intentional by submitting.");
+                                "Preferred Name has been changed from '%s' to '%s'. Please confirm that this change is intentional by submitting.",
+                                oldDisplayName.get().name, n.name);
                 callback.addMessage(mes);
             }
         }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NucleicAcidValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NucleicAcidValidator.java
@@ -99,9 +99,9 @@ public class NucleicAcidValidator extends AbstractValidatorPlugin<Substance> {
             //for now just null/blank need to confer with stakeholders if validation is needed or not
             if(su.sequence == null || su.sequence.trim().isEmpty()){
                 if(Substance.SubstanceDefinitionLevel.INCOMPLETE.equals(cs.definitionLevel)){
-                    callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("subunit at position " + (i +1) + " is blank. This is allowed but discouraged for incomplete nucleic acid records."));
+                    callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("subunit at position %s is blank. This is allowed but discouraged for incomplete nucleic acid records.", (i +1)));
                 }else {
-                    callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("subunit at position " + (i +1) + " is blank"));
+                    callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("subunit at position %s is blank", (i +1)));
                 }
             }
         }
@@ -111,8 +111,8 @@ public class NucleicAcidValidator extends AbstractValidatorPlugin<Substance> {
                 .getNumberOfUnspecifiedSugarSites(cs);
         if (unspSugars != 0) {
             callback.addMessage(GinasProcessingMessage
-                    .ERROR_MESSAGE("Nucleic Acid substance must have every base specify a sugar fragment. Missing "
-                            + unspSugars + " sites."));
+                    .ERROR_MESSAGE("Nucleic Acid substance must have every base specify a sugar fragment. Missing %s sites.",
+                            unspSugars));
         }
 
 
@@ -120,13 +120,13 @@ public class NucleicAcidValidator extends AbstractValidatorPlugin<Substance> {
                 .getNumberOfUnspecifiedLinkageSites(cs);
         if (unspLinkages > 0) {
             callback.addMessage(GinasProcessingMessage
-                    .ERROR_MESSAGE("Nucleic Acid substance must have every linkage specify a linkage fragment. Missing "
-                            + unspLinkages + " sites."));
+                    .ERROR_MESSAGE("Nucleic Acid substance must have every linkage specify a linkage fragment. Missing %s sites.",
+                            unspLinkages));
         }else{
             if (unspLinkages < - (subunits.size())) {
                 callback.addMessage(GinasProcessingMessage
-                    .ERROR_MESSAGE("Nucleic Acid substance must have every linkage specify a linkage fragment, but sites are over-specified. Found "
-                            + (-1*unspLinkages) + " more sites than expected."));
+                    .ERROR_MESSAGE("Nucleic Acid substance must have every linkage specify a linkage fragment, but sites are over-specified. Found %s more sites than expected.",
+                            (-1*unspLinkages)));
             }
         }
 
@@ -182,7 +182,7 @@ public class NucleicAcidValidator extends AbstractValidatorPlugin<Substance> {
                 //should we remove as applicable change?
             	//TP: I'm not sure we should even warn about duplicates within a record, tbh. At least with proteins,
             	//it's quite common to have subunits that are identical in sequence within the same record.
-                callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("Duplicate subunit at index " + subunit.subunitIndex));
+                callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("Duplicate subunit at index %s", subunit.subunitIndex));
             }
 
             try {
@@ -190,7 +190,7 @@ public class NucleicAcidValidator extends AbstractValidatorPlugin<Substance> {
             }catch(Exception e){
                 //invalid bases
                 callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE(
-                        "invalid nucleic acid sequence base in subunit " + subunit.subunitIndex + "  " + e.getMessage()));
+                        "invalid nucleic acid sequence base in subunit %s  %s", subunit.subunitIndex, e.getMessage()));
 
             }
         }
@@ -247,14 +247,8 @@ public class NucleicAcidValidator extends AbstractValidatorPlugin<Substance> {
 //         	   Payload payload = _payload.get()
 //         			                     .createPayload("Sequence Search","text/plain", su.sequence);
 //
-                String msgOne = "There is 1 substance with a similar sequence to subunit ["
-                        + suSet + "]:";
-                
-                String msgMult = "There are ? substances with a similar sequence to subunit ["
-                        + suSet + "]:";
-                
                 List<Function<String,List<Tuple<Double,Tuple<NucleicAcidSubstance, Subunit>>>>> searchers = new ArrayList<>();
-                
+
                 //Simplified searcher, using lucene direct index
                 searchers.add(seq->{
                 	try{
@@ -313,18 +307,15 @@ public class NucleicAcidValidator extends AbstractValidatorPlugin<Substance> {
 //                             l.text = "(Perform similarity search on subunit ["
 //                                     + su.subunitIndex + "])";
 
-                             String warnMessage=msgOne;
-                             
+                             String msgMod = "is 1 substance";
                              if(suResults.size()>1){
-                            	 warnMessage = msgMult.replace("?", suResults.size() +"");
+                                    msgMod = "are " + suResults.size() + " substances";
                              }
-                             
+
                              GinasProcessingMessage dupMessage = GinasProcessingMessage
-                                     .WARNING_MESSAGE(warnMessage);
+                                     .WARNING_MESSAGE("There %s with a similar sequence to subunit [%s]:", msgMod, suSet);
 //                             dupMessage.addLink(l);
-                             
-                             
-                             
+
                              suResults.stream()
                                       .map(t->t.withKSortOrder(d->d))
                                       .sorted()
@@ -360,8 +351,8 @@ public class NucleicAcidValidator extends AbstractValidatorPlugin<Substance> {
         } catch (Exception e) {
         	log.error("Problem executing duplicate search function", e);
             callback.addMessage(GinasProcessingMessage
-                    .ERROR_MESSAGE("Error performing seqeunce search on Nucleic Acid:"
-                            + e.getMessage()));
+                    .ERROR_MESSAGE("Error performing seqeunce search on Nucleic Acid:",
+                            e.getMessage()));
         }
     }
 

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/PolymerValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/PolymerValidator.java
@@ -101,12 +101,8 @@ public class PolymerValidator extends AbstractValidatorPlugin<Substance> {
                     if (mentioned != null) {
                         if (!contained.containsAll(mentioned)) {
                             callback.addMessage(GinasProcessingMessage
-                                    .ERROR_MESSAGE("Mentioned attachment points '"
-                                            + mentioned.toString()
-                                            + "' in unit '"
-                                            + u.label
-                                            + "' are not all found in actual connecitons '"
-                                            + contained.toString() + "'. "));
+                                    .ERROR_MESSAGE("Mentioned attachment points '%s' in unit '%s' are not all found in actual connecitons '%s'. ",
+                                            mentioned.toString(), u.label, contained.toString()));
                         }
                     }
                     Map<String, LinkedHashSet<String>> mymap = u
@@ -125,9 +121,8 @@ public class PolymerValidator extends AbstractValidatorPlugin<Substance> {
                     Set<String> leftovers = new HashSet<String>(rgroupMentions);
                     leftovers.removeAll(rgroupsWithMappings);
                     callback.addMessage(GinasProcessingMessage
-                            .ERROR_MESSAGE("Mentioned attachment point(s) '"
-                                    + leftovers.toString()
-                                    + "' cannot be found "));
+                            .ERROR_MESSAGE("Mentioned attachment point(s) '%s' cannot be found ",
+                                    leftovers.toString()));
                 }
 
                 Map<String, String> newConnections = new HashMap<String, String>();
@@ -137,9 +132,7 @@ public class PolymerValidator extends AbstractValidatorPlugin<Substance> {
                     if (!connections.contains(c[1] + "-" + c[0])) {
                         GinasProcessingMessage gp = GinasProcessingMessage
                                 .WARNING_MESSAGE(
-                                        "Connection '"
-                                                + con
-                                                + "' does not have inverse connection. This can be created.")
+                                        "Connection '%s' does not have inverse connection. This can be created.", con)
                                 .appliableChange(true);
 
                         callback.addMessage(gp, ()-> {
@@ -176,7 +169,6 @@ public class PolymerValidator extends AbstractValidatorPlugin<Substance> {
 
             ValidationUtils.validateReference(cs, cs.polymer, callback, ValidationUtils.ReferenceAction.FAIL, referenceRepository);
         }
-        
     }
 
     private static boolean isNull(GinasChemicalStructure gcs) {

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/PrimaryDefinitionValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/PrimaryDefinitionValidator.java
@@ -33,7 +33,7 @@ public class PrimaryDefinitionValidator extends AbstractValidatorPlugin<Substanc
             Substance subAlternative = substanceRepository.findBySubstanceReference(relsub);
             if(subAlternative ==null){
                 //does not exist
-                callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("alternative definition not found " + relsub.refPname));
+                callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("alternative definition not found %s", relsub.refPname));
             }else if (subAlternative.isPrimaryDefinition()) {
                 callback.addMessage(GinasProcessingMessage
                         .ERROR_MESSAGE("Primary definitions cannot be alternative definitions for other Primary definitions"));

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/ProteinValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/ProteinValidator.java
@@ -85,10 +85,9 @@ public class ProteinValidator extends AbstractValidatorPlugin<Substance>
                 if (su.subunitIndex == null) {
                     GinasProcessingMessage mes = GinasProcessingMessage
                             .WARNING_MESSAGE(
-                                    "Protein subunit (at "
-                                    + (i + 1)
-                                    + " position) has no subunit index, defaulting to:"
-                                    + (i + 1)).appliableChange(true);
+                                    "Protein subunit (at %s position) has no subunit index, defaulting to:%s",
+                                    (i + 1), (i + 1))
+                                    .appliableChange(true);
                     Integer newValue = i + 1;
                     callback.addMessage(mes, () -> su.subunitIndex = newValue);
 
@@ -98,10 +97,10 @@ public class ProteinValidator extends AbstractValidatorPlugin<Substance>
                 //for now just null/blank need to confer with stakeholders if amino acid validation is needed or not
                 if (su.sequence == null || su.sequence.trim().isEmpty()) {
                     if (Substance.SubstanceDefinitionLevel.INCOMPLETE.equals(cs.definitionLevel)) {
-                        callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("subunit at position " + (i + 1) + " is blank. This is allowed but discouraged for incomplete protein records."));
+                        callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("subunit at position %s is blank. This is allowed but discouraged for incomplete protein records.", (i + 1)));
                     }
                     else {
-                        callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("subunit at position " + (i + 1) + " is blank"));
+                        callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("subunit at position %s is blank", (i + 1)));
                     }
                 }
             }
@@ -112,9 +111,8 @@ public class ProteinValidator extends AbstractValidatorPlugin<Substance>
             List<Site> sites = l.getSites();
             if (sites.size() != 2) {
                 GinasProcessingMessage mes = GinasProcessingMessage
-                        .ERROR_MESSAGE("Disulfide Link \""
-                                + sites.toString() + "\" has "
-                                + sites.size() + " sites, should have 2");
+                        .ERROR_MESSAGE("Disulfide Link \"%s\" has %s sites, should have 2",
+                                sites.toString(), sites.size());
                 callback.addMessage(mes);
             }
             else {
@@ -122,17 +120,14 @@ public class ProteinValidator extends AbstractValidatorPlugin<Substance>
                     String res = cs.protein.getResidueAt(s);
                     if (res == null) {
                         GinasProcessingMessage mes = GinasProcessingMessage
-                                .ERROR_MESSAGE("Site \"" + s.toString()
-                                        + "\" does not exist");
+                                .ERROR_MESSAGE("Site \"%s\" does not exist", s.toString());
                         callback.addMessage(mes);
                     }
                     else {
                         if (!res.equalsIgnoreCase("C")) {
                             GinasProcessingMessage mes = GinasProcessingMessage
-                                    .ERROR_MESSAGE("Site \""
-                                            + s.toString()
-                                            + "\" in disulfide link is not a Cysteine, found: \""
-                                            + res + "\"");
+                                    .ERROR_MESSAGE("Site \"%s\" in disulfide link is not a Cysteine, found: \"%s\"",
+                                            s.toString(), res);
                             callback.addMessage(mes);
                         }
                     }
@@ -158,8 +153,8 @@ public class ProteinValidator extends AbstractValidatorPlugin<Substance>
 
         if (unknownRes.size() > 0) {
             GinasProcessingMessage mes = GinasProcessingMessage
-                    .WARNING_MESSAGE("Protein has unknown amino acid residues: "
-                            + unknownRes.toString());
+                    .WARNING_MESSAGE("Protein has unknown amino acid residues: %s",
+                            unknownRes.toString());
             callback.addMessage(mes);
         }
         mwFormulaContribution.getMessages().forEach(m -> callback.addMessage(m));
@@ -169,15 +164,16 @@ public class ProteinValidator extends AbstractValidatorPlugin<Substance>
             Property calculatedMolWeight = molWeightCalculatorProperties.calculateMolWeightProperty(tot, low, high, lowLimit, highLimit);
             GinasProcessingMessage mes = GinasProcessingMessage
                     .WARNING_MESSAGE(
-                            "Protein has no molecular weight, defaulting to calculated value of: "
-                            + calculatedMolWeight.getValue()).appliableChange(true);
+                            "Protein has no molecular weight, defaulting to calculated value of: %s",
+                            calculatedMolWeight.getValue())
+                    .appliableChange(true);
             callback.addMessage(mes, () -> {
 
                 cs.properties.add(calculatedMolWeight);
                 if (!unknownRes.isEmpty()) {
                     GinasProcessingMessage mes2 = GinasProcessingMessage
-                            .WARNING_MESSAGE("Calculated protein weight questionable, due to unknown amino acid residues: "
-                                    + unknownRes.toString());
+                            .WARNING_MESSAGE("Calculated protein weight questionable, due to unknown amino acid residues: %s",
+                                    unknownRes.toString());
                     callback.addMessage(mes2);
                 }
             });
@@ -204,10 +200,8 @@ public class ProteinValidator extends AbstractValidatorPlugin<Substance>
                     double avgoff = delta / len;  commented out per discussion with Tyler 29 June 2020 */
                     if (Math.abs(pdiff) > valueTolerance) {
                         callback.addMessage(GinasProcessingMessage
-                                .WARNING_MESSAGE(
-                                        String.format("Calculated weight [%.2f] is greater than %.2f%s off of given weight [%.2f]",
-                                                tot, tolerance, "%",
-                                                p.getValue().average)));
+                                .WARNING_MESSAGE("Calculated weight [%.2f] is greater than %.2f%s off of given weight [%.2f]",
+                                                tot, tolerance, "%", p.getValue().average));
                         //katzelda May 2018 - turn off appliable change since there isn't anything to change it to.
 //                                    .appliableChange(true));
                     }
@@ -225,15 +219,16 @@ public class ProteinValidator extends AbstractValidatorPlugin<Substance>
 
             GinasProcessingMessage mes = GinasProcessingMessage
                     .WARNING_MESSAGE(
-                            "Protein has no molecular formula property, defaulting to calculated value of: "
-                            + mwFormulaContribution.getFormula()).appliableChange(true);
+                            "Protein has no molecular formula property, defaulting to calculated value of: %s",
+                            mwFormulaContribution.getFormula())
+                    .appliableChange(true);
             callback.addMessage(mes, () -> {
 
                 cs.properties.add(ProteinUtils.makeMolFormulaProperty(mwFormulaContribution.getFormula()));
                 if (!unknownRes.isEmpty()) {
                     GinasProcessingMessage mes2 = GinasProcessingMessage
-                            .WARNING_MESSAGE("Calculated protein formula questionable due to unknown amino acid residues: "
-                                    + unknownRes.toString());
+                            .WARNING_MESSAGE("Calculated protein formula questionable due to unknown amino acid residues: %s",
+                                    unknownRes.toString());
                     callback.addMessage(mes2);
                 }
             });
@@ -305,12 +300,6 @@ public class ProteinValidator extends AbstractValidatorPlugin<Substance>
                             /*payload = _payload.get()
                                     .createPayload("Sequence Search", "text/plain", su.sequence);*/
 
-                            String msgOne = "There is 1 substance with a similar sequence to subunit ["
-                                    + suSet + "]:";
-
-                            String msgMult = "There are ? substances with a similar sequence to subunit ["
-                                    + suSet + "]:";
-
                             List<Function<String, List<Tuple<Double, Tuple<ProteinSubstance, Subunit>>>>> searchers = new ArrayList<>();
 
                             //Simplified searcher, using lucene direct index
@@ -366,14 +355,13 @@ public class ProteinValidator extends AbstractValidatorPlugin<Substance>
 //                                        l.text = "(Perform similarity search on subunit ["
 //                                                + su.subunitIndex + "])";
 
-                                        String warnMessage = msgOne;
-
-                                        if (suResults.size() > 1) {
-                                            warnMessage = msgMult.replace("?", suResults.size() + "");
+                                        String msgMod = "is 1 substance";
+                                        if(suResults.size()>1){
+                                            msgMod = "are " + suResults.size() + " substances";
                                         }
 
                                         GinasProcessingMessage dupMessage = GinasProcessingMessage
-                                                .WARNING_MESSAGE(warnMessage);
+                                                .WARNING_MESSAGE("There %s with a similar sequence to subunit [%s]:", msgMod, suSet);
 //                                        dupMessage.addLink(l);
 
                                         suResults.stream()

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/PublicDomainRefValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/PublicDomainRefValidator.java
@@ -27,15 +27,15 @@ public class PublicDomainRefValidator implements ValidatorPlugin<Substance> {
                     .isPresent();
             if (!allowed) {
                     callback.addMessage(GinasProcessingMessage
-                            .ERROR_MESSAGE("Public records must have a PUBLIC DOMAIN reference with a '"
-                                    + Reference.PUBLIC_DOMAIN_REF + "' tag"));
+                            .ERROR_MESSAGE("Public records must have a PUBLIC DOMAIN reference with a '%s' tag",
+                                    Reference.PUBLIC_DOMAIN_REF));
 
             }
             objnew.getDisplayName().ifPresent(dn->{
                 if(!dn.isPublic()){
                     callback.addMessage(GinasProcessingMessage
-                            .ERROR_MESSAGE("Display name \"" + dn.getName() + "\""
-                                    + " must be public if the full record is public."));
+                            .ERROR_MESSAGE("Display name \"%s\" must be public if the full record is public.",
+                                    dn.getName()));
                 }
             });
         }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/RelationshipModificationValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/RelationshipModificationValidator.java
@@ -44,7 +44,9 @@ public class RelationshipModificationValidator extends AbstractValidatorPlugin<S
 			        .filter(t->t.v()!=null)
 			        .filter(t->isChanged(t.v(),t.k())) //has changed
 			        .forEach(t->{
-			        	callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("Relationship \"" + t.v().toSimpleString() + "\" can not be updated by non-admin users."));
+			        	callback.addMessage(GinasProcessingMessage
+                                                    .ERROR_MESSAGE("Relationship \"%s\" can not be updated by non-admin users.",
+                                                            t.v().toSimpleString()));
 			        });
 	    	       
 			        

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/RemovePublicIndReferences.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/RemovePublicIndReferences.java
@@ -45,8 +45,8 @@ public class RemovePublicIndReferences extends AbstractValidatorPlugin<Substance
 
                     GinasProcessingMessage mes = GinasProcessingMessage
                             .WARNING_MESSAGE(
-                                    "IND-like reference:\""
-                                            + r.docType + ":" + r.citation + "\" cannot be public. Setting to protected.")
+                                    "IND-like reference:\"%s:%s\" cannot be public. Setting to protected.",
+                                            r.docType, r.citation)
                             .appliableChange(true);
                     callback.addMessage(mes, ()-> makeReferenceProtected(r));
                 });

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/SaltValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/SaltValidator.java
@@ -93,14 +93,14 @@ public class SaltValidator extends AbstractValidatorPlugin<Substance> {
 
             if (!smilesWithoutMatch.isEmpty()) {
                 smilesWithoutMatch.forEach(s -> {
-                    callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("Each fragment should be present as a separate record in the database. Please register: " + s));
+                    callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("Each fragment should be present as a separate record in the database. Please register: %s", s));
                 });
             }
             if (!smilesWithPartialMatch.isEmpty()) {
                 smilesWithPartialMatch.forEach(s -> {
-                    callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("This fragment is present as a separate record in the database but in a different form. Please register: "
-                            + s + " as an individual substance"));
-
+                    callback.addMessage(
+                        GinasProcessingMessage.WARNING_MESSAGE(
+                            "This fragment is present as a separate record in the database but in a different form. Please register: %s as an individual substance", s));
                 });
             }
 

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/SetReferenceAccess.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/SetReferenceAccess.java
@@ -56,16 +56,16 @@ public class SetReferenceAccess extends AbstractValidatorPlugin<Substance>
                     && (r.isPublic() || r.isPublicDomain() || r.isPublicReleaseReference())) {
                 GinasProcessingMessage mes = GinasProcessingMessage
                         .WARNING_MESSAGE(
-                                "Protected reference:\""
-                                        + r.docType + ":" + r.citation + "\" cannot be public. Setting to protected.")
+                                "Protected reference:\"%s:%s\" cannot be public. Setting to protected.",
+                                        r.docType, r.citation)
                         .appliableChange(true);
                 callback.addMessage(mes, () -> makeReferenceProtected(r));
             }else if (referenceCitationPatterns.values().stream().anyMatch(p -> p.matcher((" " + r.citation).toUpperCase()).find()) ) {
 							if (r.isPublic() || r.isPublicDomain() || r.isPublicReleaseReference()) {
                 GinasProcessingMessage mes = GinasProcessingMessage
                         .WARNING_MESSAGE(
-                                "Reference:\""
-                                        + r.docType + ":" + r.citation + "\" appears to be non-public. Setting to protected.")
+                                "Reference:\"%s:%s\" appears to be non-public. Setting to protected.",
+                                        r.docType, r.citation)
                         .appliableChange(true);
                 callback.addMessage(mes, () -> makeReferenceProtected(r));
 							}
@@ -73,19 +73,18 @@ public class SetReferenceAccess extends AbstractValidatorPlugin<Substance>
                     && (!r.isPublic() || !r.isPublicDomain())) {
                 GinasProcessingMessage mes = GinasProcessingMessage
                         .WARNING_MESSAGE(
-                                "Public reference:\""
-                                        + r.docType + ":" + r.citation + "\" cannot be private. Setting to public.")
+                                "Public reference:\"%s:%s\" cannot be private. Setting to public.",
+                                        r.docType, r.citation)
                         .appliableChange(true);
                 callback.addMessage(mes, () -> makeReferencePublic(r));
             }else if(suggestedPublic.containsValue(r.docType) && (!r.isPublic() || !r.isPublicDomain())) {
-                String messageText =String.format("References of type %s, such as \"%s:%s,\" are typically public. Consider modifying the access and public domain flag, unless there is an explicit reason to keep it restricted.", 
-                        r.docType, r.docType, r.citation);
-                if(!substanceNotesContainWarning(substance, messageText)){
-                    GinasProcessingMessage mes = GinasProcessingMessage
-                        .WARNING_MESSAGE(messageText);
+                GinasProcessingMessage mes = GinasProcessingMessage
+                    .WARNING_MESSAGE("References of type %s, such as \"%s:%s,\" are typically public. Consider modifying the access and public domain flag, unless there is an explicit reason to keep it restricted.",
+                                    r.docType, r.docType, r.citation);
+                if(!substanceNotesContainWarning(substance, mes.getMessage())){
                     callback.addMessage(mes);
                 }else {
-                    log.debug("warning already noted: " + messageText);
+                    log.debug("warning already noted: " + mes.getMessage());
                 }
             }
         });

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/StandardNameDuplicateValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/StandardNameDuplicateValidator.java
@@ -149,11 +149,11 @@ public class StandardNameDuplicateValidator extends AbstractValidatorPlugin<Subs
                         Set<String> stdNames = stdNameSetByLanguage.computeIfAbsent(language, k -> new HashSet<>());
                         if (!stdNames.add(uppercaseStdName)) {
                             if (onDuplicateInSameRecordShowError) {
-                                GinasProcessingMessage mes = GinasProcessingMessage.ERROR_MESSAGE(String.format(DUPLICATE_IN_SAME_RECORD_MESSAGE, name.stdName));
+                                GinasProcessingMessage mes = GinasProcessingMessage.ERROR_MESSAGE(DUPLICATE_IN_SAME_RECORD_MESSAGE, name.stdName);
                                 mes.markPossibleDuplicate();
                                 callback.addMessage(mes);
                             } else {
-                                GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE(String.format(DUPLICATE_IN_SAME_RECORD_MESSAGE, name.stdName));
+                                GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE(DUPLICATE_IN_SAME_RECORD_MESSAGE, name.stdName);
                                 mes.markPossibleDuplicate();
                                 callback.addMessage(mes);
                             }
@@ -164,11 +164,11 @@ public class StandardNameDuplicateValidator extends AbstractValidatorPlugin<Subs
                     Substance otherSubstance = checkStdNameForDuplicateInOtherRecordsViaIndexer(objnew, name.stdName);
                     if (otherSubstance != null) {
                         if (onDuplicateInOtherRecordShowError) {
-                            GinasProcessingMessage mes = GinasProcessingMessage.ERROR_MESSAGE(String.format(DUPLICATE_IN_OTHER_RECORD_MESSAGE, name.stdName));
+                            GinasProcessingMessage mes = GinasProcessingMessage.ERROR_MESSAGE(DUPLICATE_IN_OTHER_RECORD_MESSAGE, name.stdName);
                             mes.addLink(ValidationUtils.createSubstanceLink(SubstanceReference.newReferenceFor(otherSubstance)));
                             callback.addMessage(mes);
                         } else {
-                            GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE(String.format(DUPLICATE_IN_OTHER_RECORD_MESSAGE, name.stdName));
+                            GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE(DUPLICATE_IN_OTHER_RECORD_MESSAGE, name.stdName);
                             mes.addLink(ValidationUtils.createSubstanceLink(SubstanceReference.newReferenceFor(otherSubstance)));
                             callback.addMessage(mes);
                         }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/StandardNameValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/StandardNameValidator.java
@@ -160,12 +160,12 @@ public class StandardNameValidator extends AbstractValidatorPlugin<Substance> {
                 log.trace("stdName: " + name.stdName);
                 if (!stdNameStandardizer.isStandardized(name.stdName)) {
                     warnedAboutThisNameStandardization =true;
-                    String message = String.format("Standardized name does not meet standards.  This name may contain one or more non-allowed character: '%s'",
-                            name.stdName);
                     if( invalidStdNameBehavior== InvalidStdNameBehavior.error) {
-                        callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE(message));
+                        callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("Standardized name does not meet standards.  This name may contain one or more non-allowed character: '%s'",
+                            name.stdName));
                     }else {
-                        callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE(message));
+                        callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE("Standardized name does not meet standards.  This name may contain one or more non-allowed character: '%s'",
+                            name.stdName));
                     }
                 }
                 log.trace("warningOnMismatch: " + warningOnMismatch);
@@ -187,10 +187,12 @@ public class StandardNameValidator extends AbstractValidatorPlugin<Substance> {
                             if (!name.name.equals(oldRegularName)) {
                                 if (wasNull) {
                                     if (warningOnMismatch) {
-                                        String message = String.format("Previous standardized name '%s' does not agree with newly generated standardized name '%s'. Newly generated standardized name will be used.",
-                                                name.stdName, newlyStandardizedName);
-                                        callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE(message).appliableChange(true)
-                                        );
+                                        callback.addMessage(
+                                            GinasProcessingMessage
+                                                .WARNING_MESSAGE(
+                                                    "Previous standardized name '%s' does not agree with newly generated standardized name '%s'. Newly generated standardized name will be used.",
+                                                    name.stdName, newlyStandardizedName)
+                                                .appliableChange(true));
                                         name.stdName = newlyStandardizedName;
                                     }
                                     else {
@@ -199,9 +201,11 @@ public class StandardNameValidator extends AbstractValidatorPlugin<Substance> {
                                 }
                                 else {
                                     if (warningOnMismatch) {
-                                        String message = String.format("Previous standardized name '%s' does not agree with newly generated standardized name '%s'. Keeping previous standardized name. Remove standardized name to regenerate instead.",
-                                                name.stdName, newlyStandardizedName);
-                                        callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE(message));
+                                        callback.addMessage(
+                                            GinasProcessingMessage
+                                                .WARNING_MESSAGE(
+                                                    "Previous standardized name '%s' does not agree with newly generated standardized name '%s'. Keeping previous standardized name. Remove standardized name to regenerate instead.",
+                                                    name.stdName, newlyStandardizedName));
                                     }
                                 }
                             }
@@ -214,9 +218,10 @@ public class StandardNameValidator extends AbstractValidatorPlugin<Substance> {
                     }
                     else {
                         if (warningOnMismatch && !warnedAboutThisNameStandardization) {
-                            String message = String.format("Provided standardized name '%s' does not agree with newly standardized name '%s'. Provided standardized name will be used.",
-                                    name.stdName, newlyStandardizedName);
-                            callback.addMessage(GinasProcessingMessage.WARNING_MESSAGE(message));
+                            callback.addMessage(
+                                GinasProcessingMessage
+                                    .WARNING_MESSAGE("Provided standardized name '%s' does not agree with newly standardized name '%s'. Provided standardized name will be used.",
+                                    name.stdName, newlyStandardizedName));
                         }
                     }
                 }
@@ -245,8 +250,8 @@ public class StandardNameValidator extends AbstractValidatorPlugin<Substance> {
             log.trace(debugMessage);
 
             if (!minimallyStandardizedName.getResult().equals(n.name) || minimallyStandardizedName.getReplacementNotes().size() > 0) {
-                GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE(String.format("Name %s minimally standardized to %s",
-                        n.name, minimallyStandardizedName.getResult()));
+                GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE("Name %s minimally standardized to %s",
+                        n.name, minimallyStandardizedName.getResult());
                 mes.appliableChange(true);
                 callback.addMessage(mes, () -> {
                     n.name = minimallyStandardizedName.getResult();

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/SubstanceUniquenessValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/SubstanceUniquenessValidator.java
@@ -2,8 +2,6 @@ package ix.ginas.utils.validation.validators;
 
 import gsrs.module.substance.controllers.SubstanceLegacySearchService;
 import gsrs.module.substance.services.DefinitionalElementFactory;
-import gsrs.security.GsrsSecurityUtils;
-import ix.core.models.Role;
 import ix.core.validator.GinasProcessingMessage;
 import ix.core.validator.ValidatorCallback;
 import ix.core.validator.ValidatorCategory;
@@ -60,15 +58,8 @@ public class SubstanceUniquenessValidator extends AbstractValidatorPlugin<Substa
 		if (fullMatches.size() > 0) {
 			for (int i = 0; i < fullMatches.size(); i++) {
 				Substance possibleMatch = fullMatches.get(i);
-
-				String messageText = String.format("Substance %s (ID: %s) appears to be a full duplicate\n",
+				GinasProcessingMessage mes = GinasProcessingMessage.ERROR_MESSAGE("Substance %s (ID: %s) appears to be a full duplicate\n",
 								possibleMatch.getName(), possibleMatch.uuid);
-				GinasProcessingMessage mes;
-				if( oldSubstance == null && !GsrsSecurityUtils.hasAnyRoles(Role.SuperUpdate, Role.SuperDataEntry)) {
-					mes= GinasProcessingMessage.ERROR_MESSAGE(messageText);
-				}else{
-					mes= GinasProcessingMessage.WARNING_MESSAGE(messageText);
-				}
                 mes.addLink(ValidationUtils.createSubstanceLink(possibleMatch.asSubstanceReference()));
 				//.createSubstanceLink((possibleMatch));
 				callback.addMessage(mes);
@@ -81,11 +72,10 @@ public class SubstanceUniquenessValidator extends AbstractValidatorPlugin<Substa
 			if (matches.size() > 0) {
 				for (int i = 0; i < matches.size(); i++) {
 					Substance possibleMatch = matches.get(i);
-					String message = String.format("Substance %s (ID: %s) is a possible duplicate\n",
+					log.debug("in SubstanceUniquenessValidator before message creation");
+					GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE("Substance %s (ID: %s) is a possible duplicate\n",
 									possibleMatch.getName(), possibleMatch.uuid);
-					log.debug("in SubstanceUniquenessValidator, creating warning with message " + message);
-					GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE(message);
-					log.debug("in SubstanceUniquenessValidator after message creation");
+					log.debug("in SubstanceUniquenessValidator, created warning with message " + mes.getMessage());
 					  mes.addLink(ValidationUtils.createSubstanceLink(possibleMatch.asSubstanceReference()));
 					//mes.addLink(GinasUtils.createSubstanceLink(possibleMatch));
 					callback.addMessage(mes);

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/SuperatomValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/SuperatomValidator.java
@@ -24,7 +24,7 @@ public class SuperatomValidator extends AbstractValidatorPlugin<Substance> {
             for (SGroup sgroup : chem.getSGroups()) {
                 if (sgroup.getType() == SGroup.SGroupType.SUPERATOM_OR_ABBREVIATION) {
                     if (sgroup.getSuperatomLabel().isPresent()) {
-                        callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("Super Atoms are not allowed please remove: '" + sgroup.getSuperatomLabel().get() + "'"));
+                        callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("Super Atoms are not allowed please remove: '%s'", sgroup.getSuperatomLabel().get()));
                     }else{
                         callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("Super Atoms are not allowed please remove"));
 

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/UnknownSubstanceClassValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/UnknownSubstanceClassValidator.java
@@ -29,8 +29,7 @@ public class UnknownSubstanceClassValidator extends AbstractValidatorPlugin<Subs
                 break;
             default:
                 callback.addMessage(GinasProcessingMessage
-                        .ERROR_MESSAGE("Substance class \"" + s.substanceClass
-                                + "\" is not valid"));
+                        .ERROR_MESSAGE("Substance class \"%s\" is not valid", s.substanceClass));
                 break;
         }
     }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/UpdateSubstanceNonBatchLoaderValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/UpdateSubstanceNonBatchLoaderValidator.java
@@ -43,7 +43,11 @@ public class UpdateSubstanceNonBatchLoaderValidator implements ValidatorPlugin<S
 
         log.debug("old version = " +objold.version +  " new version = " + objnew.version);
         if(!objold.version.equals(objnew.version)){
-            callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE("Substance version '" + objnew.version +  "', does not match the stored version '" +  objold.version +"', record may have been changed while being updated"));
+            callback.addMessage(
+                GinasProcessingMessage
+                    .ERROR_MESSAGE(
+                        "Substance version '%s', does not match the stored version '%s', record may have been changed while being updated",
+                        objnew.version, objold.version));
         }
         UserProfile up =auditorAware.getCurrentAuditor()
                 .map(p->userProfileRepository.findByUser_UsernameIgnoreCase(p.username))
@@ -75,23 +79,23 @@ public class UpdateSubstanceNonBatchLoaderValidator implements ValidatorPlugin<S
                     //GSRS-638 removing an approval ID makes the new id null
                     if (objnew.approvalID == null) {
                         callback.addMessage(GinasProcessingMessage
-                                .WARNING_MESSAGE("The approvalID for the record has been removed. Was ('" + objold.approvalID
-                                        + "'). This is strongly discouraged."));
+                                .WARNING_MESSAGE("The approvalID for the record has been removed. Was ('%s'). This is strongly discouraged.",
+                                                objold.approvalID));
                     } else {
                         if(!substanceApprovalIdGenerator.isValidId(objnew.approvalID)){
                             callback.addMessage(GinasProcessingMessage
-                                    .ERROR_MESSAGE("The approvalID for the record has changed. Was ('" + objold.approvalID
-                                            + "') but now is ('" + objnew.approvalID + "'). This approvalID is either a duplicate or invalid."));
+                                    .ERROR_MESSAGE("The approvalID for the record has changed. Was ('%s') but now is ('%s'). This approvalID is either a duplicate or invalid.",
+                                                objold.approvalID, objnew.approvalID));
                         } else {
                             callback.addMessage(GinasProcessingMessage
-                                    .WARNING_MESSAGE("The approvalID for the record has changed. Was ('" + objold.approvalID
-                                            + "') but now is ('" + objnew.approvalID + "'). This is strongly discouraged."));
+                                    .WARNING_MESSAGE("The approvalID for the record has changed. Was ('%s') but now is ('%s'). This is strongly discouraged.",
+                                                objold.approvalID, objnew.approvalID));
                         }
                     }
                 } else{
-                    callback.addMessage(GinasProcessingMessage.ERROR_MESSAGE(
-                            "The approvalID for the record has changed. Was ('" + objold.approvalID + "') but now is ('"
-                                    + objnew.approvalID + "'). This is not allowed, except by an admin."));
+                    callback.addMessage(GinasProcessingMessage
+                            .ERROR_MESSAGE("The approvalID for the record has changed. Was ('%s') but now is ('%s'). This is not allowed, except by an admin.",
+                                    objold.approvalID, objnew.approvalID));
                 }
 
             }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/tags/TagsValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/tags/TagsValidator.java
@@ -124,7 +124,7 @@ public class TagsValidator extends AbstractValidatorPlugin<Substance> {
                 if (shouldAddExplicitTagsExtractedFromNames) {
                     GinasProcessingMessage mes = GinasProcessingMessage
                             // Note changing this message may have an impact on tests.
-                            .WARNING_MESSAGE(String.format(NAME_TAGS_WILL_BE_ADDED, TagUtilities.sortTagsHashSet(inNamesMissingFromExplicitTags).toString()))
+                            .WARNING_MESSAGE(NAME_TAGS_WILL_BE_ADDED, TagUtilities.sortTagsHashSet(inNamesMissingFromExplicitTags).toString())
                             .appliableChange(true);
                     callback.addMessage(mes, () -> {
                         for(String tagTerm: inNamesMissingFromExplicitTags) {
@@ -134,7 +134,7 @@ public class TagsValidator extends AbstractValidatorPlugin<Substance> {
                 } else {
                     GinasProcessingMessage mes = GinasProcessingMessage
                             // Note changing this message may have an impact on tests.
-                            .WARNING_MESSAGE(String.format(NAME_TAGS_WILL_NOT_BE_AUTOMATICALLY_ADDED, TagUtilities.sortTagsHashSet(inNamesMissingFromExplicitTags).toString()));
+                            .WARNING_MESSAGE(NAME_TAGS_WILL_NOT_BE_AUTOMATICALLY_ADDED, TagUtilities.sortTagsHashSet(inNamesMissingFromExplicitTags).toString());
                     callback.addMessage(mes);
                 }
             }
@@ -151,7 +151,7 @@ public class TagsValidator extends AbstractValidatorPlugin<Substance> {
                     // log.info("Tags Validator WILL auto remove tags when not present in names.");
                     GinasProcessingMessage mes = GinasProcessingMessage
                             // Note changing this message may have an impact on tests.
-                            .WARNING_MESSAGE(String.format(EXPLICIT_TAGS_WILL_BE_REMOVED, TagUtilities.sortTagsHashSet(inExplicitTagsMissingFromNames).toString()))
+                            .WARNING_MESSAGE(EXPLICIT_TAGS_WILL_BE_REMOVED, TagUtilities.sortTagsHashSet(inExplicitTagsMissingFromNames).toString())
                             .appliableChange(true);
                     callback.addMessage(mes, () -> {
                         for (String tagTerm : inExplicitTagsMissingFromNames) {
@@ -162,7 +162,7 @@ public class TagsValidator extends AbstractValidatorPlugin<Substance> {
                     // log.info("Tags Validator WILL NOT auto remove tags when present in names.");
                     GinasProcessingMessage mes = GinasProcessingMessage
                             // Note changing this message may have an impact on tests.
-                            .WARNING_MESSAGE(String.format(EXPLICIT_TAGS_WILL_NOT_BE_AUTOMATICALLY_REMOVED, TagUtilities.sortTagsHashSet(inExplicitTagsMissingFromNames).toString()));
+                            .WARNING_MESSAGE(EXPLICIT_TAGS_WILL_NOT_BE_AUTOMATICALLY_REMOVED, TagUtilities.sortTagsHashSet(inExplicitTagsMissingFromNames).toString());
                     callback.addMessage(mes);
                 }
             }

--- a/gsrs-module-substances-core/src/main/resources/substances-core.conf
+++ b/gsrs-module-substances-core/src/main/resources/substances-core.conf
@@ -719,5 +719,7 @@ gsrs.substance.data.nameColumnLength=254
 # a warning.
 gsrs.processing-strategy = {
     "defaultStrategy": "ACCEPT_APPLY_ALL",
-    "overrideRules": [ ]
+    "overrideRules": [
+        {"regex": "E4562650", "userRoles": ["SuperUpdate", "SuperDataEntry"], "newMessageType": "WARNING"}
+    ]
 }


### PR DESCRIPTION
This PR updates all validators to make use of the new GinasProcessingMessage constructor with separated message template and messages parameters. This will generate the immutable validation message IDs.