### PR TITLE
Remove the duplicateNameIsError NamesValidator parameter

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/substance/validation/NamesValidatorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/validation/NamesValidatorTest.java
@@ -22,26 +22,11 @@ import java.util.HashSet;
 public class NamesValidatorTest extends AbstractSubstanceJpaEntityTest {
 
     /*
-    Confirm correct legacy behavior - duplicate names -> error
-     */
-    @Test
-    public void testValidation() {
-        NamesValidator validator = new NamesValidator();
-        validator.setDuplicateNameIsError(true);
-        validator= AutowireHelper.getInstance().autowireAndProxy(validator);
-        ChemicalSubstance chemical =createSimpleChemicalDuplicateNames();
-        ValidationResponse<Substance> response = validator.validate(chemical, null);
-        Assertions.assertEquals(1, response.getValidationMessages().stream()
-                .filter(m -> m.getMessageType().equals(ValidationMessage.MESSAGE_TYPE.ERROR)).count());
-    }
-
-    /*
     Confirm correct new (January 2023) behavior - duplicate names -> warning
      */
     @Test
     public void testValidationNoErrors() {
         NamesValidator validator = new NamesValidator();
-        //validator.setDuplicateNameIsError(true);
         validator= AutowireHelper.getInstance().autowireAndProxy(validator);
         ChemicalSubstance chemical =createSimpleChemicalDuplicateNames();
         ValidationResponse<Substance> response = validator.validate(chemical, null);

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CodeUniquenessValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/CodeUniquenessValidator.java
@@ -36,6 +36,7 @@ public class CodeUniquenessValidator extends AbstractValidatorPlugin<Substance> 
             Code cd = codesIter.next();
 
             if (!cd.type.equalsIgnoreCase("PRIMARY")
+                    || cd.isClassification()
                     || (singletonCodeSystems != null && !singletonCodeSystems.contains(cd.codeSystem))) {
                 log.trace(String.format("skipping code of system %s and type: %s", cd.codeSystem, cd.type));
                 continue;

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NamesValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NamesValidator.java
@@ -33,7 +33,6 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
     private SubstanceRepository substanceRepository;
     // Currently, this is false at FDA; it maybe confusing if used together with TagsValidator.
     boolean extractLocators = false;
-    private boolean duplicateNameIsError = false;
 
     // Keep consistent with NamesUtilities
     // This and other replacers should be handled later in a new NameStandardizer class similar to HTMLNameStandardizer
@@ -258,16 +257,9 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
                 Set<String> names = nameSetByLanguage.computeIfAbsent(language, k->new HashSet<>());
                 if(!names.add(uppercasedName)){
                     GinasProcessingMessage mes;
-                    log.trace("duplicateNameIsError: {}", duplicateNameIsError);
-                    if (duplicateNameIsError) {
-                        mes = GinasProcessingMessage
-                                .ERROR_MESSAGE("Name '%s' is a duplicate name in the record.", name)
-                                .markPossibleDuplicate();
-                    } else {
-                        mes = GinasProcessingMessage
+                    mes = GinasProcessingMessage
                                 .WARNING_MESSAGE("Name '%s' is a duplicate name in the record.", name)
                                 .markPossibleDuplicate();
-                    }
                     callback.addMessage(mes);
                 }
 
@@ -299,14 +291,6 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
             }
         }
 
-    }
-
-    public boolean isDuplicateNameIsError() {
-        return duplicateNameIsError;
-    }
-
-    public void setDuplicateNameIsError(boolean duplicateNameIsError) {
-        this.duplicateNameIsError = duplicateNameIsError;
     }
 
     public void setReplaceSingleLinefeedPrecededByCertainCharactersWithBlank(boolean replaceSingleLinefeedPrecededByCertainCharactersWithBlank) {

--- a/gsrs-module-substances-core/src/main/resources/substances-core.conf
+++ b/gsrs-module-substances-core/src/main/resources/substances-core.conf
@@ -130,10 +130,7 @@ gsrs.validators.substances = [
                                  "validatorClass" = "ix.ginas.utils.validation.validators.NamesValidator",
                                  "newObjClass" = "ix.ginas.models.v1.Substance",
                                  "type" = "PRIMARY"
-                                 "configClass" = "SubstanceValidatorConfig",
-                                 "parameters"= {
-                                    "duplicateNameIsError" : false
-                                 }
+                                 "configClass" = "SubstanceValidatorConfig"
                                },
                                
                                {
@@ -749,6 +746,10 @@ gsrs.substance.data.nameColumnLength=254
 gsrs.processing-strategy = {
     "defaultStrategy": "ACCEPT_APPLY_ALL",
     "overrideRules": [
+        # NamesValidator duplicateNameIsError
+        # {"regex": "W7431274", "newMessageType": "ERROR"},
+        # {"regex": "W7439452", "newMessageType": "ERROR"},
+        # SubstanceUniquenessValidator
         {"regex": "E4562650", "userRoles": ["SuperUpdate", "SuperDataEntry"], "newMessageType": "WARNING"}
     ]
 }


### PR DESCRIPTION
This PR removes the duplicateNameIsError NamesValidator parameter and replace it by following configuration:

```
gsrs.processing-strategy.overrideRules += {"regex": "W7431274", "newMessageType": "ERROR"}
gsrs.processing-strategy.overrideRules += {"regex": "W7439452", "newMessageType": "ERROR"}
```