### PR TITLE
Simplify the StandardNameDuplicateValidator

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/substance/validation/StandardNameDuplicateValidatorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/validation/StandardNameDuplicateValidatorTest.java
@@ -20,19 +20,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import example.GsrsModuleSubstanceApplication;
-import gsrs.cache.GsrsCache;
-import gsrs.module.substance.controllers.SubstanceLegacySearchService;
 import gsrs.module.substance.repository.SubstanceRepository;
 import gsrs.service.GsrsEntityService;
 import gsrs.springUtils.AutowireHelper;
 import gsrs.startertests.TestGsrsValidatorFactory;
-import gsrs.startertests.TestIndexValueMakerFactory;
 import gsrs.substances.tests.AbstractSubstanceJpaFullStackEntityTest;
 import gsrs.validator.DefaultValidatorConfig;
 import gsrs.validator.ValidatorConfig;
 import ix.core.models.Keyword;
 import ix.core.validator.ValidationResponse;
-import ix.ginas.modelBuilders.SubstanceBuilder;
 import ix.ginas.models.EmbeddedKeywordList;
 import ix.ginas.models.v1.Name;
 import ix.ginas.models.v1.Substance;
@@ -46,91 +42,18 @@ public class StandardNameDuplicateValidatorTest extends AbstractSubstanceJpaFull
         private SubstanceRepository substanceRepository;
 
         @Autowired
-        private SubstanceLegacySearchService searchService;
-
-        @Autowired
-        private TestIndexValueMakerFactory testIndexValueMakerFactory;
-
-        @Autowired
         private TestGsrsValidatorFactory factory;
 
-        @Autowired
-        private GsrsCache cache;
-
-        
         @BeforeEach
         public void clearIndexers() throws IOException {
-        	ValidatorConfig config = new DefaultValidatorConfig();
-        	config.setNewObjClass(Substance.class);
-        	factory.addValidator("substances", config);
-        }
-
-        @Test
-        public void testCheckStdNameForDuplicateInOtherRecordsViaIndexer() {
-                StandardNameDuplicateValidator validator = AutowireHelper.getInstance().autowireAndProxy(new StandardNameDuplicateValidator());
-
-                String template = "{\"uuid\": \"__UUID__\", \"substanceClass\": \"concept\", \"names\": [{\"name\": \"__NAME__\", \"stdName\": \"__STDNAME1__\", \"references\": [\"__REFERENCE_ID1__\"]}], \"references\": [{\"uuid\": \"__REFERENCE_ID1__\", \"citation\": \"Some Citatation __NAME1__\", \"docType\": \"WEBSITE\", \"publicDomain\": true}], \"access\": [\"protected\"]}";
-
-                Substance s1 = null;
-                Substance s2 = null;
-
-                String j1 = template;
-                String subId_a = "25cc4754-ccf1-4db2-bb6a-367581fa17ea";
-                String refId1_a = "a7dcc059-7f47-4815-8444-2157381b8f17";
-                String name1_a = "Test1";
-                String stdName1_a = "Test1 Std";
-                j1 = j1.replaceAll("__UUID__", subId_a);
-                j1 = j1.replaceAll("__REFERENCE_ID1__", refId1_a);
-                j1 = j1.replaceAll("__NAME1__", name1_a);
-                j1 = j1.replaceAll("__STDNAME1__", stdName1_a);
-
-                String j2 = template;
-                String subId_b = "72c9ee92-8e97-4a19-b208-faf7739ad60d";
-                String refId1_b = "b7dcc059-7f47-4815-8444-2157381b8f18";
-                String name1_b = "Test2";
-                String stdName1_b = "Test1 Std";  // The 1 is on purpose
-                j2 = j2.replaceAll("__UUID__", subId_b);
-                j2 = j2.replaceAll("__REFERENCE_ID1__", refId1_b);
-                j2 = j2.replaceAll("__NAME1__", name1_b);
-                j2 = j2.replaceAll("__STDNAME1__", stdName1_b);
-
-
-                s1 = loadSubstanceFromJsonString(j1);
-                s2 = loadSubstanceFromJsonString(j2);
-
-                assertEquals(substanceRepository.count(), 2);
-
-                List<Substance> substances1 = validator.findIndexedSubstancesByStdName(stdName1_b);
-                assertEquals(substances1.size(), 2);
-                Substance otherSubstance1 = validator.checkStdNameForDuplicateInOtherRecordsViaIndexer(s2, stdName1_b);
-                assertEquals(otherSubstance1.getUuid(), s1.getUuid());
-
-                Optional<Substance> substances2 = validator.findOneIndexedSubstanceByStdNameExcludingUuid(stdName1_b, s1.getUuid());
-                assertTrue(substances2.isPresent());
-                Substance otherSubstance2 = validator.checkStdNameForDuplicateInOtherRecordsViaIndexer(s2, stdName1_b);
-                assertEquals(otherSubstance2.getUuid(), s1.getUuid());
-
-                String wontBeFound3 = "Strange thing";
-                List<Substance> substances3 = validator.findIndexedSubstancesByStdName(wontBeFound3);
-                assertEquals(substances3.size(), 0);
-                Substance otherSubstance3 = validator.checkStdNameForDuplicateInOtherRecordsViaIndexer(s2, wontBeFound3);
-                assertNull(otherSubstance3);
-
-                String wontBeFound4 = "Strange thing";
-                List<Substance> substances4 = validator.findIndexedSubstancesByStdName(wontBeFound4);
-                assertEquals(substances4.size(), 0);
-                Substance otherSubstance4 = validator.checkStdNameForDuplicateInOtherRecordsViaIndexer(s2, wontBeFound4);
-                assertNull(otherSubstance4);
-
-
+                ValidatorConfig config = new DefaultValidatorConfig();
+                config.setNewObjClass(Substance.class);
+                factory.addValidator("substances", config);
         }
 
         @Test
         public void testStdNameDuplicateInOtherRecordViaIndexer() {
                 StandardNameDuplicateValidator validator = AutowireHelper.getInstance().autowireAndProxy(new StandardNameDuplicateValidator());
-                
-                validator.setCheckDuplicateInOtherRecord(true);
-                validator.setOnDuplicateInOtherRecordShowError(true);
 
                 String template = "{\"uuid\": \"__UUID__\", \"substanceClass\": \"concept\", \"names\": [{\"name\": \"__NAME__\", \"stdName\": \"__STDNAME1__\", \"references\": [\"__REFERENCE_ID1__\"]}], \"references\": [{\"uuid\": \"__REFERENCE_ID1__\", \"citation\": \"Some Citatation __NAME1__\", \"docType\": \"WEBSITE\", \"publicDomain\": true}], \"access\": [\"protected\"]}";
 
@@ -168,101 +91,6 @@ public class StandardNameDuplicateValidatorTest extends AbstractSubstanceJpaFull
                 anyMatch(vm->vm.getMessageType().toString().equals("ERROR") && vm.getMessage().contains(validator.getDUPLICATE_IN_OTHER_RECORD_MESSAGE_TEST_FRAGMENT()));
                 Assertions.assertTrue(found);
         }
-        
-
-        @Test
-        public void testStdNameDuplicateInOtherRecordViaIndexerWhenNameHasWildcard() {
-                StandardNameDuplicateValidator validator = AutowireHelper.getInstance().autowireAndProxy(new StandardNameDuplicateValidator());
-                
-                validator.setCheckDuplicateInOtherRecord(true);
-                validator.setOnDuplicateInOtherRecordShowError(true);
-
-                
-                UUID uuid1 = UUID.randomUUID();
-                UUID uuid2 = UUID.randomUUID();
-                
-                SubstanceBuilder substanceBuilder1 = new SubstanceBuilder()
-                		.addName("TEST* ABC", n->n.stdName="TEST* ABC")
-                		.setUUID(uuid1);
-                assertCreated(substanceBuilder1.buildJson());
-                
-                SubstanceBuilder substanceBuilder2 = new SubstanceBuilder()
-                		.addName("TEST2* ABC", n->n.stdName="TEST2* ABC")
-                		.setUUID(uuid2);
-                assertCreated(substanceBuilder2.buildJson());
-                
-              
-                assertEquals(substanceRepository.count(), 2);
-
-                ValidationResponse<Substance> response = validator.validate(substanceBuilder1.build(), null);
-
-                boolean found = response.getValidationMessages().stream().
-                anyMatch(vm->vm.getMessageType().toString().equals("ERROR"));
-                Assertions.assertFalse(found);
-        }
-
-
-        @Test
-        public void testStdNameDuplicateInOtherRecordViaIndexerWhenNameHasWildcardDuplicate() {
-                StandardNameDuplicateValidator validator = AutowireHelper.getInstance().autowireAndProxy(new StandardNameDuplicateValidator());
-                
-                validator.setCheckDuplicateInOtherRecord(true);
-                validator.setOnDuplicateInOtherRecordShowError(true);
-
-                
-                UUID uuid1 = UUID.randomUUID();
-                UUID uuid2 = UUID.randomUUID();
-                
-                SubstanceBuilder substanceBuilder1 = new SubstanceBuilder()
-                		.addName("TEST* ABC", n->n.stdName="TEST* ABC")
-                		.setUUID(uuid1);
-                assertCreated(substanceBuilder1.buildJson());
-                
-                SubstanceBuilder substanceBuilder2 = new SubstanceBuilder()
-                		.addName("TEST2* ABC", n->n.stdName="TEST* ABC")
-                		.setUUID(uuid2);
-                assertCreated(substanceBuilder2.buildJson());
-                
-              
-                assertEquals(substanceRepository.count(), 2);
-
-                ValidationResponse<Substance> response = validator.validate(substanceBuilder1.build(), null);
-
-                boolean found = response.getValidationMessages().stream().
-                anyMatch(vm->vm.getMessageType().toString().equals("ERROR"));
-                Assertions.assertTrue(found);
-        }
-        
-        @Test
-        public void testStdNameDuplicateInOtherRecordViaIndexerWhenNameHasWildcardDuplicateQuestionMark() {
-                StandardNameDuplicateValidator validator = AutowireHelper.getInstance().autowireAndProxy(new StandardNameDuplicateValidator());
-                
-                validator.setCheckDuplicateInOtherRecord(true);
-                validator.setOnDuplicateInOtherRecordShowError(true);
-
-                
-                UUID uuid1 = UUID.randomUUID();
-                UUID uuid2 = UUID.randomUUID();
-                
-                SubstanceBuilder substanceBuilder1 = new SubstanceBuilder()
-                		.addName("TEST* ABC", n->n.stdName="TEST? ABC")
-                		.setUUID(uuid1);
-                assertCreated(substanceBuilder1.buildJson());
-                
-                SubstanceBuilder substanceBuilder2 = new SubstanceBuilder()
-                		.addName("TEST2* ABC", n->n.stdName="TEST? ABC")
-                		.setUUID(uuid2);
-                assertCreated(substanceBuilder2.buildJson());
-                
-              
-                assertEquals(substanceRepository.count(), 2);
-
-                ValidationResponse<Substance> response = validator.validate(substanceBuilder1.build(), null);
-
-                boolean found = response.getValidationMessages().stream().
-                anyMatch(vm->vm.getMessageType().toString().equals("ERROR"));
-                Assertions.assertTrue(found);
-        }
 
         public Substance loadSubstanceFromJsonString(String jsonText) {
                 Substance substance = null;
@@ -284,47 +112,8 @@ public class StandardNameDuplicateValidatorTest extends AbstractSubstanceJpaFull
         }
 
         @Test
-        public void testDuplicateInSameRecordShowWarning() {
-                boolean showError = false;
-                StandardNameDuplicateValidator validator = AutowireHelper.getInstance().autowireAndProxy(new StandardNameDuplicateValidator());
-                validator.setCheckDuplicateInSameRecord(true);
-//                validator.setCheckDuplicateInOtherRecord(false);
-                validator.setOnDuplicateInSameRecordShowError(showError);
-                Substance s1 = new Substance();
-                Name name1 = new Name();
-                name1.name ="TestSame1";
-                name1.stdName ="TestSame1 std";
-                if (name1.languages == null) {
-                        name1.languages = new EmbeddedKeywordList();
-                }
-                name1.languages.add(new Keyword("en"));
-                name1.languages.add(new Keyword("fr"));
-                s1.names.add(name1);
-                Name name2 = new Name();
-                name2.name ="TestSame2";
-                name2.stdName ="TestSame1 std";  // 1 on purpose
-                if (name1.languages == null) {
-                        name1.languages = new EmbeddedKeywordList();
-                }
-                name2.languages.add(new Keyword("en"));
-                name2.languages.add(new Keyword("fr"));
-                s1.names.add(name2);
-                substanceRepository.saveAndFlush(s1);
-                cache.clearCache();
-                ValidationResponse<Substance> response = validator.validate(s1, null);
-                boolean found = response.getValidationMessages().stream().
-                        anyMatch(vm->vm.getMessageType().toString().equals("WARNING") && vm.getMessage().contains(validator.getDUPLICATE_IN_SAME_RECORD_MESSAGE_TEST_FRAGMENT()));
-
-                Assertions.assertTrue(found);
-        }
-
-        @Test
         public void testDuplicateInSameRecordShowError() {
-                boolean showError = true;
                 StandardNameDuplicateValidator validator = AutowireHelper.getInstance().autowireAndProxy(new StandardNameDuplicateValidator());
-                validator.setCheckDuplicateInSameRecord(true);
-//                validator.setCheckDuplicateInOtherRecord(false);
-                validator.setOnDuplicateInSameRecordShowError(showError);
                 Substance s1 = new Substance();
                 Name name1 = new Name();
                 name1.name ="TestSame1";
@@ -345,7 +134,6 @@ public class StandardNameDuplicateValidatorTest extends AbstractSubstanceJpaFull
                 name2.languages.add(new Keyword("fr"));
                 s1.names.add(name2);
                 substanceRepository.saveAndFlush(s1);
-                cache.clearCache();
                 ValidationResponse<Substance> response = validator.validate(s1, null);
                 boolean found = response.getValidationMessages().stream().
                 anyMatch(vm->vm.getMessageType().toString().equals("ERROR") && vm.getMessage().contains(validator.getDUPLICATE_IN_SAME_RECORD_MESSAGE_TEST_FRAGMENT()));

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/StandardNameDuplicateValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/StandardNameDuplicateValidator.java
@@ -1,19 +1,14 @@
 package ix.ginas.utils.validation.validators;
 
-import java.io.IOException;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import gov.nih.ncats.common.sneak.Sneak;
-import gsrs.cache.GsrsCache;
-import gsrs.module.substance.controllers.SubstanceLegacySearchService;
 import gsrs.module.substance.repository.SubstanceRepository;
 import ix.core.models.Keyword;
-import ix.core.search.SearchRequest;
-import ix.core.search.SearchResult;
-import ix.core.search.text.TextIndexer;
-import ix.core.search.text.TextIndexerFactory;
-import ix.core.util.EntityUtils;
 import ix.core.validator.GinasProcessingMessage;
 import ix.core.validator.ValidatorCallback;
 import ix.ginas.models.EmbeddedKeywordList;
@@ -23,16 +18,7 @@ import ix.ginas.models.v1.SubstanceReference;
 import ix.ginas.utils.validation.AbstractValidatorPlugin;
 import ix.ginas.utils.validation.ValidationUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.lucene.facet.taxonomy.TaxonomyReader;
-import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
-import org.apache.lucene.queryparser.classic.ParseException;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TopDocs;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
-
-import javax.imageio.IIOException;
 
 @Slf4j
 public class StandardNameDuplicateValidator extends AbstractValidatorPlugin<Substance> {
@@ -47,68 +33,12 @@ public class StandardNameDuplicateValidator extends AbstractValidatorPlugin<Subs
     @Autowired
     private SubstanceRepository substanceRepository;
 
-    @Autowired
-    protected PlatformTransactionManager transactionManager;
-
-    @Autowired
-    private SubstanceLegacySearchService searchService;
-
-    @Autowired
-    private TextIndexerFactory textIndexerFactory;
-
-    private TextIndexer indexer;
-
-
-    @Autowired
-    private GsrsCache cache;
-
-    private boolean checkDuplicateInOtherRecord = true;
-    private boolean checkDuplicateInSameRecord = true;
-    private boolean onDuplicateInOtherRecordShowError = true;
-    private boolean onDuplicateInSameRecordShowError = false;
-
     // User adds/edits standard name in substance record that has a duplicate standard name within
     // the substance record and in the same language.
     // ==> warning (default)
 
     // User adds/edits standard name in substance record that has a duplicate in another substance
     // record ==> error (default)
-
-    public void setSubstanceRepository(SubstanceRepository substanceRepository) {
-        this.substanceRepository = substanceRepository;
-    }
-
-    public void setTransactionManager(PlatformTransactionManager transactionManager) {
-        this.transactionManager = transactionManager;
-    }
-
-    public void setSearchService(SubstanceLegacySearchService searchService) {
-        this.searchService = searchService;
-    }
-
-    public void setTextIndexerFactory(TextIndexerFactory textIndexerFactory) {
-        this.textIndexerFactory = textIndexerFactory;
-    }
-
-    public void setCache(GsrsCache cache) {
-        this.cache = cache;
-    }
-
-    public void setOnDuplicateInOtherRecordShowError(boolean onDuplicateInOtherRecordShowError) {
-        this.onDuplicateInOtherRecordShowError = onDuplicateInOtherRecordShowError;
-    }
-
-    public void setOnDuplicateInSameRecordShowError(boolean onDuplicateInSameRecordShowError) {
-        this.onDuplicateInSameRecordShowError = onDuplicateInSameRecordShowError;
-    }
-
-    public void setCheckDuplicateInOtherRecord(boolean checkDuplicateInOtherRecord) {
-        this.checkDuplicateInOtherRecord = checkDuplicateInOtherRecord;
-    }
-
-    public void setCheckDuplicateInSameRecord(boolean checkDuplicateInSameRecord) {
-        this.checkDuplicateInSameRecord = checkDuplicateInSameRecord;
-    }
 
     public String getDUPLICATE_IN_OTHER_RECORD_MESSAGE_TEST_FRAGMENT() {
         return DUPLICATE_IN_OTHER_RECORD_MESSAGE_TEST_FRAGMENT;
@@ -141,117 +71,30 @@ public class StandardNameDuplicateValidator extends AbstractValidatorPlugin<Subs
                 }
 
                 // Check for duplicates in the record.
-                if(checkDuplicateInSameRecord) {
-                    Iterator<Keyword> iter = name.languages.iterator();
-                    String uppercaseStdName = name.stdName.toUpperCase();
-                    while (iter.hasNext()) {
-                        String language = iter.next().getValue();
-                        Set<String> stdNames = stdNameSetByLanguage.computeIfAbsent(language, k -> new HashSet<>());
-                        if (!stdNames.add(uppercaseStdName)) {
-                            if (onDuplicateInSameRecordShowError) {
-                                GinasProcessingMessage mes = GinasProcessingMessage.ERROR_MESSAGE(DUPLICATE_IN_SAME_RECORD_MESSAGE, name.stdName);
-                                mes.markPossibleDuplicate();
-                                callback.addMessage(mes);
-                            } else {
-                                GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE(DUPLICATE_IN_SAME_RECORD_MESSAGE, name.stdName);
-                                mes.markPossibleDuplicate();
-                                callback.addMessage(mes);
-                            }
-                        }
+                Iterator<Keyword> iter = name.languages.iterator();
+                String uppercaseStdName = name.stdName.toUpperCase();
+                while (iter.hasNext()) {
+                    String language = iter.next().getValue();
+                    Set<String> stdNames = stdNameSetByLanguage.computeIfAbsent(language, k -> new HashSet<>());
+                    if (!stdNames.add(uppercaseStdName)) {
+                        GinasProcessingMessage mes = GinasProcessingMessage.ERROR_MESSAGE(DUPLICATE_IN_SAME_RECORD_MESSAGE, name.stdName);
+                        mes.markPossibleDuplicate();
+                        callback.addMessage(mes);
                     }
                 }
-                if(checkDuplicateInOtherRecord) {
-                    Substance otherSubstance = checkStdNameForDuplicateInOtherRecordsViaIndexer(objnew, name.stdName);
-                    if (otherSubstance != null) {
-                        if (onDuplicateInOtherRecordShowError) {
-                            GinasProcessingMessage mes = GinasProcessingMessage.ERROR_MESSAGE(DUPLICATE_IN_OTHER_RECORD_MESSAGE, name.stdName);
-                            mes.addLink(ValidationUtils.createSubstanceLink(SubstanceReference.newReferenceFor(otherSubstance)));
-                            callback.addMessage(mes);
-                        } else {
-                            GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE(DUPLICATE_IN_OTHER_RECORD_MESSAGE, name.stdName);
-                            mes.addLink(ValidationUtils.createSubstanceLink(SubstanceReference.newReferenceFor(otherSubstance)));
-                            callback.addMessage(mes);
-                        }
+
+                List<SubstanceRepository.SubstanceSummary> sr = substanceRepository.findByNames_StdNameIgnoreCase(name.stdName);
+                if (sr != null && !sr.isEmpty()) {
+                    SubstanceRepository.SubstanceSummary s2 = sr.iterator().next();
+                    if (s2.getUuid() != null && !s2.getUuid().equals(objnew.getOrGenerateUUID())) {
+                        GinasProcessingMessage mes = GinasProcessingMessage
+                                .ERROR_MESSAGE(DUPLICATE_IN_OTHER_RECORD_MESSAGE, name.stdName)
+                                .addLink(ValidationUtils.createSubstanceLink(s2.toSubstanceReference()));
+                        callback.addMessage(mes);
                     }
                 }
             } // if stdName not null
 
         });
-    }
-    public Substance checkStdNameForDuplicateInOtherRecordsViaIndexer(Substance s, String stdName) {
-
-    	try {
-    		Optional<Substance> substance = findOneIndexedSubstanceByStdNameExcludingUuid(stdName, s.getOrGenerateUUID());
-    		return substance.orElse(null);
-    	} catch (Exception e) {
-    		// Should we throw it?
-    		log.error("Problem checking for duplicate standard name.", e);
-    	}
-    	return null;
-    }
-
-    public List<Substance> findIndexedSubstancesByStdName(String stdName) {
-        Objects.requireNonNull(stdName, "Parameter 'stdName' must not be null");
-        String query = prepareQuery(stdName);
-        SearchRequest request = new SearchRequest.Builder()
-                .kind(Substance.class)
-                .fdim(0)
-                .simpleSearchOnly(true)
-                .query(query)
-                .top(Integer.MAX_VALUE)
-                .build();
-        List<Substance> substances = getSearchList(request);
-        return substances;
-    }
-    
-    private String prepareQuery(String stdName) {
-        String query = "root_names_stdName:\"^" + stdName
-                .replace("\"", "") //eliminate any internal quotes
-    	        .replace("*", "?").replace("~","?")  //replace special lucene chars with single-char wildcard
-                                                     // TODO: this isn't perfect, but does a pretty good job
-                + "$\"";
-        return query;
-    }
-
-    public Optional<Substance> findOneIndexedSubstanceByStdNameExcludingUuid(String stdName, UUID excludeUuid) {
-        // This one allows you to exclude a specific uuid, that way we only
-        // need to build a search result list with one substance.
-        Objects.requireNonNull(stdName, "Parameter 'stdName' must not be null");
-        Objects.requireNonNull(excludeUuid, "Parameter 'excludeUuid' must not be null");
-        String query = prepareQuery(stdName);
-        query += " AND NOT " + "root_uuid:\"^" + excludeUuid + "$\"";
-        SearchRequest request = new SearchRequest.Builder()
-	        .kind(Substance.class)
-	        .simpleSearchOnly(true) //this avoids doing all the extra facets/etc
-	        .fdim(0)
-	        .query(query)
-	        .top(1)
-	        .build();
-        return getSearchList(request).stream().findFirst();
-    }
-
-    /**
-     * Return a list of substances based on the {@link SearchRequest}. This
-     * takes care of some tricky transaction issues.
-     *
-     * @param sr
-     * @return
-     */
-
-    private List<Substance> getSearchList(SearchRequest sr) {
-        TransactionTemplate transactionSearch = new TransactionTemplate(transactionManager);
-        List<Substance> substances = transactionSearch.execute(ts -> {
-            try {
-                SearchResult sresult = searchService.search(sr.getQuery(), sr.getOptions());
-                List<Substance> first = sresult.getMatches();
-                return first.stream()
-                        //force fetching
-                        .peek(ss -> EntityUtils.EntityWrapper.of(ss).toInternalJson())
-                        .collect(Collectors.toList());
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        return substances;
     }
 }


### PR DESCRIPTION
This PR simplified the StandardNameDuplicateValidator by using the SubstanceRepository.findByNames_StdNameIgnoreCase method.