### PR TITLE
Tweak structure duplicate search to use moieties as well as structure by default

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/chem/DuplicateCheckTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/chem/DuplicateCheckTest.java
@@ -82,7 +82,7 @@ class DuplicateCheckTest extends AbstractSubstanceJpaFullStackEntityTest {
         uniquenessCheckMethod.setAccessible(true);
         List<ValidationMessage> messages = (List<ValidationMessage>) uniquenessCheckMethod.invoke(validator, chemicalSubstance);
         Assertions.assertEquals(1, messages.size());
-        Assertions.assertTrue(messages.stream().anyMatch(m->m.getMessage().contains("appears to be a duplicate")));
+        Assertions.assertTrue(messages.stream().anyMatch(m->m.getMessage().contains("is a potential duplicate")));
     }
 
     @Test
@@ -115,6 +115,44 @@ class DuplicateCheckTest extends AbstractSubstanceJpaFullStackEntityTest {
         List<ValidationMessage> messages = (List<ValidationMessage>) uniquenessCheckMethod.invoke(validator, chemicalSubstance);
         Assertions.assertEquals(1, messages.size());
         Assertions.assertTrue(messages.stream().anyMatch(m->m.getMessageType().equals(ValidationMessage.MESSAGE_TYPE.ERROR)));
+    }
+
+    @Test
+    void testFindDuplicatesForSodium() throws Exception {
+        String molfile = "\\n  ACCLDraw10162318502D\\n\\n  1  0  0  0  0  0  0  0  0  0999 V2000\\n   12.8125  -10.5938    0.0000 Na  0  3  0  0  0  0  0  0  0  0  0  0\\nM  CHG  1   1   1\\nM  END";
+        String smiles = "[Na+]";
+        ChemicalSubstanceBuilder builder = new ChemicalSubstanceBuilder();
+        Structure structure = structureProcessor.instrument(smiles);
+        GinasChemicalStructure ginasChemicalStructure = new GinasChemicalStructure(structure);
+        builder.setStructure(ginasChemicalStructure);
+        builder.addName("sodium");
+        ChemicalSubstance chemicalSubstance = builder.build();
+        ChemicalUniquenessValidator validator = new ChemicalUniquenessValidator();
+        AutowireHelper.getInstance().autowireAndProxy(validator);
+        Method uniquenessCheckMethod = validator.getClass().getDeclaredMethod("handleDuplicateCheck", ChemicalSubstance.class);
+        uniquenessCheckMethod.setAccessible(true);
+        validator.setSearchMoietiesAlongWithStructure(true);
+        List<ValidationMessage> messages = (List<ValidationMessage>) uniquenessCheckMethod.invoke(validator, chemicalSubstance);
+        Assertions.assertEquals(3, messages.size());
+    }
+
+    @Test
+    void testFindDuplicatesForSodiumNot() throws Exception {
+        String molfile = "\\n  ACCLDraw10162315002D\\n\\n  1  0  0  0  0  0  0  0  0  0999 V2000\\n   12.8125  -10.5938    0.0000 Na  0  0  0  0  0  0  0  0  0  0  0  0\\nM  END";
+        String smiles = "[Na+]";
+        ChemicalSubstanceBuilder builder = new ChemicalSubstanceBuilder();
+        Structure structure = structureProcessor.instrument(smiles);
+        GinasChemicalStructure ginasChemicalStructure = new GinasChemicalStructure(structure);
+        builder.setStructure(ginasChemicalStructure);
+        builder.addName("sodium");
+        ChemicalSubstance chemicalSubstance = builder.build();
+        ChemicalUniquenessValidator validator = new ChemicalUniquenessValidator();
+        AutowireHelper.getInstance().autowireAndProxy(validator);
+        Method uniquenessCheckMethod = validator.getClass().getDeclaredMethod("handleDuplicateCheck", ChemicalSubstance.class);
+        uniquenessCheckMethod.setAccessible(true);
+        validator.setSearchMoietiesAlongWithStructure(false);
+        List<ValidationMessage> messages = (List<ValidationMessage>) uniquenessCheckMethod.invoke(validator, chemicalSubstance);
+        Assertions.assertEquals(1, messages.size());
     }
 
 }

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/ChemicalUniquenessValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/ChemicalUniquenessValidator.java
@@ -31,6 +31,8 @@ public class ChemicalUniquenessValidator extends AbstractValidatorPlugin<Substan
     @Autowired
     private SubstanceLegacySearchService legacySearchService;
 
+    private boolean searchMoietiesAlongWithStructure =true;
+
     @Override
     public void validate(Substance objnew, Substance objold, ValidatorCallback callback) {
         log.trace("starting in validate");
@@ -67,6 +69,9 @@ public class ChemicalUniquenessValidator extends AbstractValidatorPlugin<Substan
         String sins = structure.getStereoInsensitiveHash();
         log.trace("StereoInsensitiveHash: {}", sins);
         String hash = "( root_structure_properties_STEREO_INSENSITIVE_HASH:" + sins + " )";
+        if(searchMoietiesAlongWithStructure) {
+            hash += "  OR ( root_moieties_properties_STEREO_INSENSITIVE_HASH:" + sins + "  )";
+        }
         //removed this clause from the query because we want to exclude moiety matches " OR " + "root_moieties_properties_STEREO_INSENSITIVE_HASH:" + sins +
         log.trace("query: {}", hash);
         SearchRequest.Builder builder = new SearchRequest.Builder()
@@ -121,6 +126,10 @@ public class ChemicalUniquenessValidator extends AbstractValidatorPlugin<Substan
             messages.add(GinasProcessingMessage.SUCCESS_MESSAGE("Structure is unique"));
         }
         return messages;
+    }
+
+    public void setSearchMoietiesAlongWithStructure(boolean searchMoietiesAlongWithStructure) {
+        this.searchMoietiesAlongWithStructure = searchMoietiesAlongWithStructure;
     }
 
 }


### PR DESCRIPTION
Config parameter 

> "searchMoietiesAlongWithStructure" : false

prevents the use of moieties in the query