### PR TITLE
Allow inverse relationships to be added even when there is more than 1 with the same type

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/substance/RelationshipInvertTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/RelationshipInvertTest.java
@@ -380,7 +380,7 @@ public class RelationshipInvertTest extends AbstractSubstanceJpaEntityTest {
         assertEquals(1, createInverseEvents.size());
         assertEquals(TryToCreateInverseRelationshipEvent.builder()
                 .relationshipIdToInvert(updatedSubstance.relationships.get(0).uuid)
-                .creationMode(TryToCreateInverseRelationshipEvent.CreationMode.CREATE_IF_MISSING)
+                .creationMode(TryToCreateInverseRelationshipEvent.CreationMode.CREATE_IF_MISSING_DEEP_CHECK)
                 .fromSubstance(UUID.fromString(uuidA))
                 .toSubstance(updatedSubstance.uuid)
                 .originatorUUID(updatedSubstance.relationships.get(0).uuid)

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/RelationshipProcessor.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/RelationshipProcessor.java
@@ -98,7 +98,7 @@ public class RelationshipProcessor implements EntityProcessor<Relationship> {
 	            if (otherSubstanceReference != null && otherSubstanceReference.refuuid !=null) {
 	                event.setFromSubstance(UUID.fromString(otherSubstanceReference.refuuid));
 	            }
-	            event.setCreationMode(TryToCreateInverseRelationshipEvent.CreationMode.CREATE_IF_MISSING);
+	            event.setCreationMode(TryToCreateInverseRelationshipEvent.CreationMode.CREATE_IF_MISSING_DEEP_CHECK);
 	            eventPublisher.publishEvent(event);
 
 	        });

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/SubstanceProcessor.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/SubstanceProcessor.java
@@ -105,7 +105,7 @@ public class SubstanceProcessor implements EntityProcessor<Substance> {
             if(owner!=null) {
                 eventPublisher.publishEvent(
                         TryToCreateInverseRelationshipEvent.builder()
-                                .creationMode(TryToCreateInverseRelationshipEvent.CreationMode.CREATE_IF_MISSING)
+                                .creationMode(TryToCreateInverseRelationshipEvent.CreationMode.CREATE_IF_MISSING_DEEP_CHECK)
                                 .originatorUUID(UUID.fromString(r.originatorUuid))
                                 .toSubstance(owner.uuid)
                                 .fromSubstance(obj.uuid)

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/TryToCreateInverseRelationshipEvent.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/TryToCreateInverseRelationshipEvent.java
@@ -32,7 +32,7 @@ public class TryToCreateInverseRelationshipEvent {
     private UUID originatorUUID;
     private UUID relationshipIdToInvert;
 
-    private CreationMode creationMode = CreationMode.CREATE_IF_MISSING;
+    private CreationMode creationMode = CreationMode.CREATE_IF_MISSING_DEEP_CHECK;
 
     private UUID newRelationshipId;
 
@@ -42,7 +42,18 @@ public class TryToCreateInverseRelationshipEvent {
             @Override
             public boolean shouldAdd(Relationship r, Substance from, Substance to){
                 for (Relationship rOld : from.relationships) {
-                    if (r.type.equals(rOld.type) && r.relatedSubstance.isEquivalentTo(rOld.relatedSubstance)) {
+                    if (r.isEquivalentBaseRelationship(rOld)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        },
+        CREATE_IF_MISSING_DEEP_CHECK{
+            @Override
+            public boolean shouldAdd(Relationship r, Substance from, Substance to){
+                for (Relationship rOld : from.relationships) {
+                    if (r.isEquivalentFullRelationship(rOld)) {
                         return false;
                     }
                 }

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/UpdateInverseRelationshipEvent.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/UpdateInverseRelationshipEvent.java
@@ -39,7 +39,7 @@ public class UpdateInverseRelationshipEvent {
     	// set the from substance AND to substance to be the same, causing unintentional self-referencing
     	// relationships. This is fixed in 3.0.3.
         return TryToCreateInverseRelationshipEvent.builder()
-         .creationMode(CreationMode.CREATE_IF_MISSING)
+         .creationMode(CreationMode.CREATE_IF_MISSING_DEEP_CHECK)
          .relationshipIdToInvert(relationshipIdThatWasUpdated)
          .originatorUUID(originatorUUID)
          .fromSubstance(substanceIdToUpdate)

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/modelBuilders/AbstractSubstanceBuilder.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/modelBuilders/AbstractSubstanceBuilder.java
@@ -421,9 +421,14 @@ public abstract class AbstractSubstanceBuilder<S extends Substance, T extends Ab
     }
 
     public T addRelationshipTo(Substance relatedSubstance, String type){
+        return addRelationshipTo(relatedSubstance,type,(rr)->{});
+    }
+    public T addRelationshipTo(Substance relatedSubstance, String type, Consumer<Relationship> mutate){
         Relationship rel = new Relationship();
         rel.type = type;
         rel.relatedSubstance = relatedSubstance.asSubstanceReference();
+        mutate.accept(rel);
+        
         return addRelationship(rel);
     }
 

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/Relationship.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/models/v1/Relationship.java
@@ -12,8 +12,12 @@ import ix.ginas.models.utils.JSONEntity;
 import ix.ginas.models.utils.RelationshipUtil;
 
 import javax.persistence.*;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 
 @JSONEntity(title = "Relationship", isFinal = true)
@@ -184,6 +188,28 @@ public class Relationship extends /*CommonDataElementOfCollection */ GinasCommon
     public boolean isEquivalentBaseRelationship(Relationship other){
     	if (other.type.equals(this.type) && other.relatedSubstance.isEquivalentTo(this.relatedSubstance)) {
 			return true;
+		}
+    	return false;
+    }
+    
+    @JsonIgnore
+    public boolean isEquivalentFullRelationship(Relationship other){
+    	if (other.isEquivalentBaseRelationship(this)) {
+    		if(		(other.comments+"").equals(this.comments+"") && 
+    				(other.qualification+"").equals(this.qualification+"") && 
+    				(other.interactionType+"").equals(this.interactionType+"") && 
+    				(Optional.ofNullable(other.amount).map(oa -> oa.toString()).orElse("")
+    						.equals(
+    				 Optional.ofNullable(this.amount).map(oa -> oa.toString()).orElse("")))) {
+    			if((this.mediatorSubstance==null && other.mediatorSubstance==null)) {
+    				return true;
+    			}else if(this.mediatorSubstance!=null && other.mediatorSubstance!=null) {
+    				return this.mediatorSubstance.isEquivalentTo(other.mediatorSubstance);
+    			}else {
+    				return false;
+    			}
+    			
+    		}
 		}
     	return false;
     }


### PR DESCRIPTION
This allows new relationships to be added on the inverted record when there are "variations" of the inverted relationship on the other side. The old restriction was mostly to prevent relationships entered without explicit "tracked" inversion (i.e. without originatorUUID set) from being overly duplicated. The scenario that used to happen was:

1. A JSON dump with substances and their relationships to each other was produced
2. Each appropriate relationship DID have an inverse, just not the tracking fields (originatorUUID)
3. When registering / updating a relationship would try to add a NEW inverted copy to the other side of the record, even though it already existed but was just not tracked.

To prevent the third case the old code would look for an equivalent inverted form and prevent adding the inverse if it seemed it was already there. However this check only looked at the type and the related substances and didn't consider amount, qualification, etc. The new approach will still handle the above scenario but will only consider the inverse as already present if it matches on ALL fields that should be carried over.