### PR TITLE
Allow passages of an environment variable to set names validator search type 

### DIFF
--- a/gsrs-module-substances-core/src/main/resources/substances-core.conf
+++ b/gsrs-module-substances-core/src/main/resources/substances-core.conf
@@ -133,10 +133,9 @@ gsrs.validators.substances = [
                                  "configClass" = "SubstanceValidatorConfig",
                                  "parameters"= {
                                     "caseSearchType": "Explicit"
+                                    "caseSearchType": ${?SUBSTANCE_NAMES_VALIDATOR_CASE_SEARCH_TYPE}
                                  }
-                               },
-                               
-                               {
+                               },                               {
                                  "validatorClass" = "ix.ginas.utils.validation.validators.PrimaryRelationshipsValidator",
                                  "newObjClass" = "ix.ginas.models.v1.Substance",
                                  "type" = "PRIMARY"


### PR DESCRIPTION
This will allow us to optionally set an env var or put this **above** the include "substances-core.conf"  in application.conf 

e.g.
SUBSTANCE_NAMES_VALIDATOR_CASE_SEARCH_TYPE=Implicit

