### PR TITLE
Make ApprovalValidations more configurable

### DIFF
--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/approval/ApprovalIdConfiguration.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/approval/ApprovalIdConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
@@ -22,13 +23,17 @@ public class ApprovalIdConfiguration {
 
     private Class generatorClass;
     private Map<String, Object> parameters;
+    private Map<String, Boolean> validators;
 
     @Bean
     @ConditionalOnMissingBean
     public ApprovalService defaultApprovalService(SubstanceApprovalIdGenerator approvalIdGenerator,
                                                   SubstanceRepository substanceRepository,
                                                   PrincipalRepository principalRepository){
-        return new DefaultApprovalService(approvalIdGenerator, substanceRepository, principalRepository);
+        if (validators == null) {
+            validators = new HashMap<String, Boolean>();
+        }
+        return new DefaultApprovalService(approvalIdGenerator, substanceRepository, principalRepository, validators);
 
     }
     @Bean

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/approval/ApprovalService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/approval/ApprovalService.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 public interface ApprovalService {
 
+    boolean isApprovable(Substance s);
+
     ApprovalResult approve(Substance s) throws ApprovalException;
 
     @Data

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/approval/DefaultApprovalService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/approval/DefaultApprovalService.java
@@ -125,6 +125,26 @@ public class DefaultApprovalService implements ApprovalService{
     }
 
     /**
+     * Check if the given Substance is approvable by the user invoking this method.
+     * @param s the Substance to approve.
+     * @return a true if the user invoking this method is able to approve given Substance.
+     */
+    @Override
+    public boolean isApprovable(Substance s) {
+        String userName = GsrsSecurityUtils.getCurrentUsername().orElse(null);
+        if (userName == null) {
+            return false;
+        }
+        try {
+            defaultApprovalValidation(s, userName);
+            extraApprovalValidation(s, userName);
+            return true;
+        } catch (ApprovalException ex) {
+            return false;
+        }
+    }
+
+    /**
      * Try to approve the given Substance.  The user invoking this method
      * must have Approver Role.
      * @param s the Substance to approve.

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/SubstanceController.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/controllers/SubstanceController.java
@@ -1036,6 +1036,17 @@ public class SubstanceController extends EtagLegacySearchEntityController<Substa
 
     }
 
+    @GetGsrsRestApiMapping(value={"({id})/@isApprovable", "/{id}/@isApprovable" })
+    public ResponseEntity isApprovableGetMethod(@PathVariable("id") String substanceUUIDOrName, @RequestParam Map<String, String> queryParameters) throws Exception {
+        Optional<Substance> substance = getEntityService().getEntityBySomeIdentifier(substanceUUIDOrName);
+
+        if(!substance.isPresent()){
+            return getGsrsControllerConfiguration().handleNotFound(queryParameters);
+        }
+        boolean approvable = approvalService.isApprovable(substance.get());
+        return new ResponseEntity<>(String.valueOf(approvable), HttpStatus.OK);
+    }
+
     @Transactional
     @GetGsrsRestApiMapping(value={"({id})/@approve", "/{id}/@approve" })
     @hasApproverRole


### PR DESCRIPTION
This PR adds the @isApprovable end point to the SubstanceController.

Configuration Paramaters:
allowLastEditor
allowCreator
allowNonPrimary
allowConcept
allowDependsOnNonPresent
allowDependsOnNonApproved

Usage Example:
ix.ginas.approvalIdGenerator.validators.allowConcept=true
ix.ginas.approvalIdGenerator.validators.allowCreator=true
