### PR TITLE
EP extensions

### DIFF
--- a/gsrs-module-substance-example/pom.xml
+++ b/gsrs-module-substance-example/pom.xml
@@ -329,13 +329,6 @@
             <artifactId>log4j-core</artifactId>
             <version>${log4j2.version}</version>
         </dependency>
-         <dependency>
-            <groupId>io.burt</groupId>
-            <artifactId>jmespath</artifactId>
-            <version>0.4.0</version>
-            <type>pom</type>
-        </dependency>
-
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/gsrs-module-substances-core/pom.xml
+++ b/gsrs-module-substances-core/pom.xml
@@ -332,6 +332,16 @@
             <version>1.17</version>
         </dependency>
         <dependency>
+            <groupId>io.burt</groupId>
+            <artifactId>jmespath-core</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.burt</groupId>
+            <artifactId>jmespath-jackson</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+        <dependency>
             <groupId>gov.fda.gsrs</groupId>
             <artifactId>Featureize-Nitrosamines</artifactId>
             <version>0.0.4-SNAPSHOT</version>

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/GsrsApiExporter.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/GsrsApiExporter.java
@@ -1,0 +1,118 @@
+package gsrs.module.substance.exporters;
+
+import com.fasterxml.jackson.databind.ObjectWriter;
+import ix.core.controllers.EntityFactory;
+import ix.core.validator.GinasProcessingMessage;
+import ix.core.validator.ValidationResponse;
+import ix.ginas.exporters.Exporter;
+import ix.ginas.models.v1.Substance;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Created by Egor Puzanov on 10/18/22.
+ */
+@Slf4j
+public class GsrsApiExporter implements Exporter<Substance> {
+
+    private final HttpHeaders headers;
+    private final BufferedWriter out;
+    private final RestTemplate restTemplate;
+    private final boolean allowedExport;
+    private final boolean validate;
+    private final String newAuditor;
+    private final String changeReason;
+    private final ObjectWriter writer = EntityFactory.EntityMapper.FULL_ENTITY_MAPPER().writer();
+    private final Pattern AUDIT_PAT = Pattern.compile("edBy\":\"[^\"]*\"");
+
+    public GsrsApiExporter(OutputStream out, RestTemplate restTemplate, Map<String, String> headers, boolean allowedExport,  boolean validate, String newAuditor, String changeReason) throws IOException {
+        Objects.requireNonNull(out);
+        this.out = new BufferedWriter(new OutputStreamWriter(out));
+        Objects.requireNonNull(restTemplate);
+        this.restTemplate = restTemplate;
+        HttpHeaders h = new HttpHeaders();
+        h.setContentType(MediaType.APPLICATION_JSON);
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            h.set(entry.getKey(), entry.getValue());
+        }
+        this.headers = h;
+        this.allowedExport = allowedExport;
+        this.validate = validate;
+        this.newAuditor = newAuditor != null ? "edBy\":\"" + newAuditor + "\"" : null;
+        this.changeReason = changeReason;
+        log.debug("BaseUrl: " + restTemplate.getUriTemplateHandler().expand("/") + " Headers: " + h.toString());
+    }
+
+    private HttpEntity<String> makeRequest(Substance obj) throws Exception {
+        String jsonStr = writer.writeValueAsString(obj);
+        if (newAuditor != null) {
+            jsonStr = AUDIT_PAT.matcher(jsonStr).replaceAll(newAuditor);
+        }
+        HttpEntity<String> request = new HttpEntity<String>(jsonStr, headers);
+        if (validate) {
+            ValidationResponse vr = restTemplate.postForObject("/@validate", request, ValidationResponse.class);
+            if (vr.getValidationMessages().isEmpty()) throw new Exception("GSRS API not found");
+            if (vr.hasError()) throw new Exception(vr.toString());
+        }
+        return request;
+    }
+
+    @Override
+    public void export(Substance obj) throws IOException {
+        HttpEntity<String> request;
+        Date date = new Date();
+        try {
+            if (!allowedExport) {
+                throw new Exception("Export denied");
+            }
+            if (changeReason != null && obj.version != null) {
+                obj.changeReason = changeReason.replace("{{version}}", obj.version).replace("{{changeReason}}", obj.changeReason != null ? obj.changeReason : "").trim();
+            }
+            try {
+                obj.version = restTemplate.getForObject("/{uuid}/version", String.class, obj.getUuid().toString()).replace("\"", "");
+                request = makeRequest(obj);
+                restTemplate.put("/", request);
+            } catch (HttpClientErrorException.NotFound ex) {
+                if (!ex.getMessage().endsWith("[{\"message\":\"not found\",\"status\":404}]")) {
+                    throw new Exception(ex.getMessage());
+                }
+                obj.version = "1";
+                String approvalID = obj.getApprovalID();
+                if (approvalID != null) {
+                    obj.approvalID = null;
+                }
+                request = makeRequest(obj);
+                Substance newObj = restTemplate.postForObject("/", request, Substance.class);
+                if (newObj.getUuid() == null) throw new Exception("GSRS API not found");
+                if (approvalID != null) {
+                    obj.approvalID = approvalID;
+                    request = makeRequest(obj);
+                    restTemplate.put("/", request);
+                }
+            }
+            out.write(String.format("%tF %tT Substance: %s %s - SUCCESS", date, date, obj.getUuid().toString(), obj.getName()));
+        } catch (Exception ex) {
+            out.write(String.format("%tF %tT Substance: %s %s - ERROR: %s", date, date, obj.getUuid().toString(), obj.getName(), ex.getMessage()));
+        }
+        out.newLine();
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/GsrsApiExporterFactory.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/GsrsApiExporterFactory.java
@@ -1,0 +1,173 @@
+package gsrs.module.substance.exporters;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import gsrs.repository.UserProfileRepository;
+import ix.core.models.Role;
+import ix.core.models.UserProfile;
+import ix.ginas.exporters.Exporter;
+import ix.ginas.exporters.ExporterFactory;
+import ix.ginas.exporters.OutputFormat;
+import ix.ginas.models.v1.Substance;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+
+/**
+ * Created by Egor Puzanov on 10/18/22.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GsrsApiExporterFactory implements ExporterFactory {
+
+    @Autowired
+    private UserProfileRepository userProfileRepository;
+
+    private OutputFormat format = new OutputFormat("gsrsapi", "Send to ...");
+    private int timeout = 120000;
+    private boolean trustAllCerts = false;
+    private boolean validate = true;
+    private Role allowedRole = null;
+    private String newAuditor = null;
+    private String changeReason = null;
+    private String baseUrl = "http://localhost:8080/api/v1/substances";
+    private Map<String, String> headers = new HashMap<String, String>();
+    private final TrustManager[] trustAllCertificates = new TrustManager[]{
+        new X509TrustManager() {
+            public X509Certificate[] getAcceptedIssuers() {
+                return null;
+            }
+            public void checkClientTrusted(
+               X509Certificate[] certs, String authType) {
+            }
+            public void checkServerTrusted(
+               X509Certificate[] certs, String authType) {
+           }
+        }
+    };
+
+    private Map<String, String> getHeaders(UserProfile profile) {
+        Map<String, String> userHeaders = new HashMap<String, String>();
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            String value = entry.getValue();
+            switch(value) {
+                case "{{user.name}}":
+                    value = profile.getIdentifier();
+                    break;
+                case "{{user.email}}":
+                    value = profile.user.email;
+                    break;
+                case "{{user.apikey}}":
+                    value = profile.getKey();
+                    break;
+                default:
+                    break;
+            }
+            userHeaders.put(entry.getKey(), value);
+        }
+        return userHeaders;
+    }
+
+    public void setFormat(Map<String, String> m) {
+        this.format = new OutputFormat(m.get("extension"), m.get("displayName"));
+    }
+
+    public void setTimeout(Integer timeout) {
+        this.timeout = timeout.intValue();
+    }
+
+    public void setTrustAllCerts(boolean trustAllCerts) {
+        this.trustAllCerts = trustAllCerts;
+    }
+
+    public void setValidate(boolean validate) {
+        this.validate = validate;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public void setAllowedRole(String allowedRole) {
+        this.allowedRole = Role.valueOf(allowedRole);
+    }
+
+    public void setNewAuditor(String newAuditor) {
+        this.newAuditor = newAuditor;
+    }
+
+    public void setChangeReason(String changeReason) {
+        this.changeReason = changeReason;
+    }
+
+    @Override
+    public boolean supports(Parameters params) {
+        return params.getFormat().equals(format);
+    }
+
+    @Override
+    public Set<OutputFormat> getSupportedFormats() {
+        return Collections.singleton(format);
+    }
+
+    @Override
+    public Exporter<Substance> createNewExporter(OutputStream out, Parameters params) throws IOException {
+        RequestConfig requestConfig = RequestConfig.custom()
+            .setConnectionRequestTimeout(timeout)
+            .build();
+        HttpClientBuilder client = HttpClients.custom()
+            .useSystemProperties()
+            .setDefaultRequestConfig(requestConfig);
+        if (trustAllCerts) {
+            try {
+                SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(null, trustAllCertificates, new SecureRandom());
+                SSLConnectionSocketFactory connectionFactory = new SSLConnectionSocketFactory(sslContext, new NoopHostnameVerifier());
+                client = client.setSSLSocketFactory(connectionFactory);
+            } catch (Exception ex) {
+            }
+        }
+        ClientHttpRequestFactory clientFactory = new HttpComponentsClientHttpRequestFactory(client.build());
+        RestTemplate restTemplate = new RestTemplate(clientFactory);
+        restTemplate.setUriTemplateHandler(new DefaultUriBuilderFactory(baseUrl));
+        UserProfile profile = userProfileRepository.findByUser_UsernameIgnoreCase(params.getUsername());
+        boolean allowedExport = (allowedRole == null || profile.hasRole(allowedRole)) ? true : false;
+        return new GsrsApiExporter(out, restTemplate, getHeaders(profile), allowedExport, validate, newAuditor, changeReason);
+    }
+
+    @Override
+    public JsonNode getSchema() {
+        ObjectNode parameters = JsonNodeFactory.instance.objectNode();
+        return parameters;
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/JmespathColumnValueRecipe.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/JmespathColumnValueRecipe.java
@@ -1,0 +1,112 @@
+package gsrs.module.substance.exporters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import gsrs.module.substance.utils.SplitFunction;
+import gsrs.module.substance.utils.UniqueFunction;
+
+import io.burt.jmespath.JmesPath;
+import io.burt.jmespath.Expression;
+import io.burt.jmespath.RuntimeConfiguration;
+import io.burt.jmespath.function.FunctionRegistry;
+import io.burt.jmespath.jackson.JacksonRuntime;
+import ix.ginas.exporters.*;
+import java.util.Date;
+import java.util.Objects;
+import java.text.SimpleDateFormat;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Created by Egor Puzanov on 11/8/21.
+ */
+@Slf4j
+public class JmespathColumnValueRecipe<T> implements ColumnValueRecipe<T> {
+
+    private final String columnName;
+    private final Expression<JsonNode> expression;
+    private final String delimiter;
+    private final SimpleDateFormat datetime;
+
+    public JmespathColumnValueRecipe(String columnName, Expression<JsonNode> expression, String delimiter, SimpleDateFormat datetime) {
+        Objects.requireNonNull(columnName);
+        Objects.requireNonNull(expression);
+        Objects.requireNonNull(delimiter);
+        this.columnName = columnName;
+        this.expression = expression;
+        this.delimiter = delimiter;
+        this.datetime = datetime;
+    }
+
+    static <T>  ColumnValueRecipe<T> create(Enum<?> enumValue, String expression, String delimiter, String datetime) {
+        return create(enumValue.name(), expression, delimiter, datetime);
+    }
+
+    static <T>  ColumnValueRecipe<T> create(String columnName, String expression, String delimiter, String datetime) {
+        FunctionRegistry customFunctions = FunctionRegistry.defaultRegistry().extend(
+                                                       new SplitFunction(),
+                                                       new UniqueFunction());
+        RuntimeConfiguration configuration = new RuntimeConfiguration.Builder()
+                                   .withFunctionRegistry(customFunctions)
+                                   .build();
+        JmesPath<JsonNode> jmespath = new JacksonRuntime(configuration);
+        SimpleDateFormat dtf = null;
+        try {
+            dtf = new SimpleDateFormat(datetime);
+        } catch (Exception ex) {
+        }
+        return new JmespathColumnValueRecipe<T>(columnName, jmespath.compile(expression), delimiter, dtf);
+    }
+
+    @Override
+    public int writeValuesFor(Spreadsheet.SpreadsheetRow row, int currentOffset, T obj) {
+        JsonNode results = expression.search((JsonNode) obj);
+        if (results.isValueNode() && ! results.isNull()) {
+            String value = results.asText();
+            if (datetime != null) {
+                try {
+                    value = datetime.format(new Date(Long.valueOf(value)));
+                } catch (Exception ex) {
+                }
+            }
+            row.getCell(currentOffset).writeString(value);
+        } else if (results.isArray()) {
+            StringBuilder sb = new StringBuilder();
+            for(JsonNode result: results){
+                if (result.isValueNode() && ! result.isNull()) {
+                    String value = result.asText();
+                    if (value != null && !value.isEmpty()) {
+                        if(sb.length()!=0){
+                            sb.append(delimiter);
+                        }
+                        sb.append(value);
+                    }
+                }
+            }
+            if (sb.length() != 0) {
+                row.getCell(currentOffset).writeString(sb.toString());
+            }
+        }
+        return 1;
+    }
+
+    @Override
+    public int writeHeaderValues(Spreadsheet.SpreadsheetRow row, int currentOffset) {
+        row.getCell(currentOffset).writeString(columnName);
+        return 1;
+    }
+
+    @Override
+    public boolean containsColumnName(String name) {
+        return Objects.equals(columnName, name);
+    }
+
+    @Override
+    public JmespathColumnValueRecipe<T> replaceColumnName(String oldName, String newName) {
+        Objects.requireNonNull(oldName);
+        Objects.requireNonNull(newName);
+
+        if(containsColumnName(oldName)){
+            return new JmespathColumnValueRecipe<>(newName, expression, delimiter, datetime);
+        }
+        return this;
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/JmespathSpreadsheetExporter.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/JmespathSpreadsheetExporter.java
@@ -1,0 +1,130 @@
+package gsrs.module.substance.exporters;
+
+import java.io.IOException;
+import java.util.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import ix.core.controllers.EntityFactory;
+import ix.ginas.exporters.*;
+import ix.ginas.models.v1.Substance;
+
+
+/**
+ * Substance Exporter that writes out data to a Spreadsheet.
+ * Created by Egor Puzanov
+ */
+public class JmespathSpreadsheetExporter implements Exporter<Substance> {
+
+    private final Spreadsheet spreadsheet;
+    private int row=1;
+    private final List<ColumnValueRecipe<JsonNode>> recipeMap;
+    private final ObjectWriter writer = EntityFactory.EntityMapper.FULL_ENTITY_MAPPER().writer();
+
+    private JmespathSpreadsheetExporter(Builder builder){
+        this.spreadsheet = builder.spreadsheet;
+        this.recipeMap = builder.columns;
+        int j=0;
+        Spreadsheet.SpreadsheetRow header = spreadsheet.getRow(0);
+        for(ColumnValueRecipe<JsonNode> col : recipeMap){
+            j+= col.writeHeaderValues(header, j);
+        }
+    }
+
+    @Override
+    public void export(Substance s) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            JsonNode tree = mapper.readTree(writer.writeValueAsString(s));
+            updateReferences(tree);
+            Spreadsheet.SpreadsheetRow row = spreadsheet.getRow(this.row++);
+            int j=0;
+            for(ColumnValueRecipe<JsonNode> recipe : recipeMap){
+                j+= recipe.writeValuesFor(row, j, tree);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        spreadsheet.close();
+    }
+
+    private void updateReferences(JsonNode tree) {
+        ArrayNode references = (ArrayNode)tree.at("/references");
+        Map<String, Integer> refMap = new HashMap<String, Integer>();
+        for (int i = 0; i < references.size(); i++) {
+            refMap.put(references.get(i).get("uuid").textValue(), i);
+        }
+        for (JsonNode refsNode: tree.findValues("references")) {
+            if (refsNode.isArray()) {
+                ArrayNode refs = (ArrayNode) refsNode;
+                for (int i = 0; i < refs.size(); i++) {
+                    JsonNode ref = refs.get(i);
+                    if (ref.isTextual()) {
+                        refs.set(i, references.get(refMap.get(ref.asText())));
+                    }
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Builder class that makes a SpreadsheetExporter.
+     *
+     */
+    public static class Builder{
+        private final List<ColumnValueRecipe<JsonNode>> columns = new ArrayList<>();
+        private final Spreadsheet spreadsheet;
+
+        /**
+         * Create a new Builder that uses the given Spreadsheet to write to.
+         * @param spreadSheet the {@link Spreadsheet} object that will be written to by this exporter. can not be null.
+         *
+         * @throws NullPointerException if spreadsheet is null.
+         */
+        public Builder(Spreadsheet spreadSheet){
+            Objects.requireNonNull(spreadSheet);
+            this.spreadsheet = spreadSheet;
+        }
+
+        public Builder addColumn(Column column, ColumnValueRecipe<JsonNode> recipe){
+            return addColumn(column.name(), recipe);
+        }
+
+        public Builder addColumn(String columnName, ColumnValueRecipe<JsonNode> recipe){
+            Objects.requireNonNull(columnName);
+            Objects.requireNonNull(recipe);
+            columns.add(recipe);
+            return this;
+        }
+
+
+        public Builder renameColumn(Column oldColumn, String newName){
+            return renameColumn(oldColumn.name(), newName);
+        }
+
+        public Builder renameColumn(String oldName, String newName){
+            //use iterator to preserve order
+            ListIterator<ColumnValueRecipe<JsonNode>> iter = columns.listIterator();
+            while(iter.hasNext()){
+                ColumnValueRecipe<JsonNode> oldValue = iter.next();
+                ColumnValueRecipe<JsonNode> newValue = oldValue.replaceColumnName(oldName, newName);
+                if(oldValue != newValue){
+                   iter.set(newValue);
+                }
+            }
+            return this;
+        }
+
+        public JmespathSpreadsheetExporter build(){
+            return new JmespathSpreadsheetExporter(this);
+        }
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/JmespathSpreadsheetExporterFactory.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/JmespathSpreadsheetExporterFactory.java
@@ -1,0 +1,76 @@
+package gsrs.module.substance.exporters;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import ix.ginas.exporters.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Created by Egor Puzanov.
+ */
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JmespathSpreadsheetExporterFactory implements ExporterFactory {
+
+    private OutputFormat format = new OutputFormat("custom.xlsx", "Custom Report (xlsx) File");
+
+    private List<Map<String, String>> columnExpressions = (List<Map<String, String>>) Arrays.asList((Map<String, String>) new HashMap<String, String>(){{put("name", "UUID"); put("expression", "uuid");}});
+
+    public void setFormat(Map<String, String> m) {
+        this.format = new OutputFormat(m.get("extension"), m.get("displayName"));
+    }
+
+    public void setColumnExpressions(Map<Integer, Map<String, String>> m) {
+        this.columnExpressions = (List<Map<String, String>>) m.entrySet()
+                                                            .stream()
+                                                            .sorted(Map.Entry.comparingByKey())
+                                                            .map(e->e.getValue())
+                                                            .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean supports(Parameters params) {
+        return params.getFormat().equals(format);
+    }
+
+    @Override
+    public Set<OutputFormat> getSupportedFormats() {
+        return Collections.singleton(format);
+    }
+
+    @Override
+    public JmespathSpreadsheetExporter createNewExporter(OutputStream out, Parameters params) throws IOException {
+        Spreadsheet spreadsheet = new ExcelSpreadsheet.Builder(out)
+                                                      .maxRowsInMemory(100)
+                                                      .build();
+        JmespathSpreadsheetExporter.Builder builder = new JmespathSpreadsheetExporter.Builder(spreadsheet);
+        for (Map<String, String> columnExpression : columnExpressions) {
+            String columnName = columnExpression.get("name");
+            ColumnValueRecipe<JsonNode> recipe = JmespathColumnValueRecipe.create(
+                columnName,
+                columnExpression.get("expression"),
+                columnExpression.getOrDefault("delimiter", "|"),
+                columnExpression.getOrDefault("datetime", null));
+            builder = builder.addColumn(columnName, recipe);
+        }
+        return builder.build();
+    }
+
+    @Override
+    public JsonNode getSchema() {
+        ObjectNode parameters = JsonNodeFactory.instance.objectNode();
+        return parameters;
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/indexers/JmespathIndexValueMaker.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/indexers/JmespathIndexValueMaker.java
@@ -1,0 +1,195 @@
+package gsrs.module.substance.indexers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import gsrs.module.substance.utils.SplitFunction;
+import gsrs.module.substance.utils.UniqueFunction;
+
+import io.burt.jmespath.JmesPath;
+import io.burt.jmespath.Expression;
+import io.burt.jmespath.RuntimeConfiguration;
+import io.burt.jmespath.function.FunctionRegistry;
+import io.burt.jmespath.jackson.JacksonRuntime;
+
+import ix.core.controllers.EntityFactory;
+import ix.core.search.text.IndexValueMaker;
+import ix.core.search.text.IndexableValue;
+import ix.ginas.models.v1.Substance;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Created by Egor Puzanov on 9/10/2021.
+ */
+@Slf4j
+public class JmespathIndexValueMaker implements IndexValueMaker<Substance> {
+
+    private List<IndexExpression> expressions = new ArrayList<IndexExpression>();
+    private final ObjectWriter writer = EntityFactory.EntityMapper.FULL_ENTITY_MAPPER().writer();
+
+    private class IndexExpression {
+        private final String index;
+        private final String type;
+        private final List<String> ranges;
+        private final Expression<JsonNode> expression;
+        private final Pattern regex;
+        private final String replacement;
+        private final String delimiter;
+        private final String format;
+        private final boolean suggestable;
+        private final boolean sortable;
+
+        public IndexExpression(Map<String, String> m) {
+            FunctionRegistry customFunctions = FunctionRegistry.defaultRegistry().extend(
+                                                           new SplitFunction(),
+                                                           new UniqueFunction());
+            RuntimeConfiguration configuration = new RuntimeConfiguration.Builder()
+                                       .withFunctionRegistry(customFunctions)
+                                       .build();
+            JmesPath<JsonNode> jmespath = new JacksonRuntime(configuration);
+            this.type = m.getOrDefault("type", "String");
+            this.ranges = Arrays.asList(m.getOrDefault("ranges", "").split(" "));
+            this.expression = (Expression<JsonNode>) jmespath.compile(m.get("expression"));
+            this.regex = Pattern.compile(m.getOrDefault("regex", ""));
+            this.replacement = m.getOrDefault("replacement", "$1");
+            this.delimiter = m.getOrDefault("delimiter", "");
+            this.format = m.get("format");
+            this.suggestable = Boolean.valueOf(m.getOrDefault("suggestable", "false")).booleanValue();
+            this.sortable = Boolean.valueOf(m.getOrDefault("sortable", "false")).booleanValue();
+            this.index = m.get("index");
+        }
+
+        public boolean isValid() {
+            if (index == null || expression == null) {
+                return false;
+            }
+            return true;
+        }
+
+        public void createIndexableValues(JsonNode tree, Consumer<IndexableValue> consumer) {
+            IndexableValue iv = null;
+            try {
+                JsonNode results = expression.search(tree);
+                log.debug("Results: " + results.toString());
+                if (!results.isArray()) {
+                    results = (JsonNode) new ObjectMapper().createArrayNode().add(results);
+                }
+                for(JsonNode result: (ArrayNode)results){
+                    if (result.isValueNode() && ! result.isNull()) {
+                        if (result.isDouble() || "Double".equals(type)) {
+                            if (ranges != null && !ranges.isEmpty()) {
+                                log.debug("Index: " + index + " FacetDoubleValue: " + result.asText());
+                                iv = IndexableValue.simpleFacetDoubleValue(index, result.asDouble(),
+                                    ranges.stream().mapToDouble(Double::valueOf).toArray());
+                            } else {
+                                log.debug("Index: " + index + " DoubleValue: " + result.asText());
+                                iv = IndexableValue.simpleDoubleValue(index, result.asDouble());
+                            }
+                        } else if (result.isNumber() || "Long".equals(type)) {
+                            if (ranges != null && !ranges.isEmpty()) {
+                                log.debug("Index: " + index + " FacetLongValue: " + result.asText());
+                                iv = IndexableValue.simpleFacetLongValue(index, result.asLong(),
+                                    ranges.stream().mapToLong(Long::valueOf).toArray());
+                            } else {
+                                log.debug("Index: " + index + " LongValue: " + result.asText());
+                                iv = IndexableValue.simpleLongValue(index, result.asLong());
+                            }
+                        } else {
+                            String value = result.asText(null);
+                            if (!regex.pattern().isEmpty()) {
+                                log.debug("Index: " + index + " Value before regex: " + value);
+                                value = regex.matcher(value).replaceAll(replacement);
+                                log.debug("Index: " + index + " Value after regex: " + value);
+                            }
+                            if (value != null && !value.isEmpty()) {
+                                if (index.startsWith("root_")) {
+                                    log.debug("Index: " + index + " StringValue: " + value);
+                                    iv = IndexableValue.simpleStringValue(index, value);
+                                } else {
+                                    log.debug("Index: " + index + " FacetStringValue: " + value);
+                                    iv = IndexableValue.simpleFacetStringValue(index, value);
+                                }
+                            }
+                        }
+                        if (format != null && !format.isEmpty()) {
+                            iv = iv.setFormat(format);
+                        }
+                        if (suggestable) {
+                            iv = iv.suggestable();
+                        }
+                        if (sortable) {
+                            iv = iv.setSortable();
+                        }
+                        consumer.accept(iv);
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+    }
+
+    @Override
+    public Class<Substance> getIndexedEntityClass() {
+        return Substance.class;
+    }
+
+    @Override
+    public void createIndexableValues(Substance substance, Consumer<IndexableValue> consumer) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            JsonNode tree = mapper.readTree(writer.writeValueAsString(substance));
+            updateReferences(tree);
+            for (IndexExpression expression: expressions) {
+                expression.createIndexableValues(tree, consumer);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void setExpressions(LinkedHashMap<Integer, Map<String, String>> expressions) {
+        this.expressions.clear();
+        for (Map<String, String> expression: expressions.values()) {
+            IndexExpression expr = new IndexExpression(expression);
+            if (expr.isValid()) {
+                this.expressions.add(expr);
+            }
+        }
+    }
+
+    private void updateReferences(JsonNode tree) {
+        ArrayNode references = (ArrayNode)tree.at("/references");
+        Map<String, Integer> refMap = new HashMap<>();
+        for (int i = 0; i < references.size(); i++) {
+            refMap.put(references.get(i).get("uuid").textValue(), i);
+        }
+        for (JsonNode refsNode: tree.findValues("references")) {
+            if (refsNode.isArray()) {
+                ArrayNode refs = (ArrayNode) refsNode;
+                for (int i = 0; i < refs.size(); i++) {
+                    JsonNode ref = refs.get(i);
+                    if (ref.isTextual()) {
+                        Integer index = refMap.get(ref.asText());
+                        if(index !=null) {
+                            refs.set(i, references.get(index));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/CVClassificationsCodeProcessor.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/CVClassificationsCodeProcessor.java
@@ -1,0 +1,211 @@
+package gsrs.module.substance.processors;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.nih.ncats.common.util.CachedSupplier;
+import gsrs.cv.api.ControlledVocabularyApi;
+import gsrs.cv.api.GsrsControlledVocabularyDTO;
+import gsrs.cv.api.GsrsVocabularyTermDTO;
+import ix.core.EntityProcessor;
+import ix.ginas.models.v1.Code;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * This EntityProcessor will create a Classifications comments string
+ * for the Code using CV as the source (code.code = vt.value and
+ * code.comments = vt.display)
+ *
+ * @author Egor Puzanov
+ */
+@Data
+@Slf4j
+public class CVClassificationsCodeProcessor implements EntityProcessor<Code> {
+
+    @Autowired
+    private ControlledVocabularyApi api;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private CachedSupplier initializer = CachedSupplier.runOnceInitializer(this::addCvDomainIfNeeded);
+
+    private CVClassificationsCodeProcessorConfig config;
+
+    public static class CVClassificationsCodeProcessorConfig {
+        private Instant lastUpdated = Instant.now();
+        private Long timeout = Long.valueOf(300);
+        public String codeSystem = "WHO-ATC";
+        public String cvDomain;
+        public Long cvVersion;
+        public String prefix;
+        public int[] masks = {};
+        public Map<String, String> terms = new HashMap<String, String>();
+
+        public static CVClassificationsCodeProcessorConfig from(CVClassificationsCodeProcessorConfig other) {
+            CVClassificationsCodeProcessorConfig conf = new CVClassificationsCodeProcessorConfig();
+            conf.codeSystem = String.valueOf(other.codeSystem);
+            conf.cvDomain = String.valueOf(other.cvDomain);
+            conf.prefix = String.valueOf(other.prefix);
+            conf.cvVersion = Long.valueOf(other.cvVersion);
+            conf.timeout = Long.valueOf(other.timeout);
+            conf.masks = Arrays.copyOf(other.masks, other.masks.length);
+            return conf;
+        }
+
+        public void setTimeout(String timeout) {
+            this.timeout = Long.valueOf(timeout);
+        }
+
+        public void setMasks(Map<Integer, Integer> m) {
+            masks = m.entrySet().stream()
+                                .sorted(Map.Entry.<Integer, Integer>comparingByKey())
+                                .mapToInt(e->e.getValue())
+                                .toArray();
+        }
+
+        public CVClassificationsCodeProcessorConfig refresh() {
+            this.lastUpdated = Instant.now();
+            return this;
+        }
+
+        public boolean isOutdated() {
+            return Duration.between(lastUpdated, Instant.now()).getSeconds() > timeout;
+        }
+    }
+
+    public CVClassificationsCodeProcessor() {
+        this(new HashMap<String, Object>());
+    }
+
+    public CVClassificationsCodeProcessor(Map m) {
+        ObjectMapper mapper = new ObjectMapper();
+        config = mapper.convertValue(m, CVClassificationsCodeProcessorConfig.class);
+    }
+
+    private void addCvDomainIfNeeded() {
+        if (config.cvDomain != null) {
+            log.debug("starting to add CV Domain if needed");
+            try {
+                Optional<GsrsControlledVocabularyDTO> opt = api.findByDomain(config.cvDomain);
+                if(!opt.isPresent()){
+                    api.create(GsrsControlledVocabularyDTO.builder()
+                            .domain(config.cvDomain)
+                            .build());
+                    if (config.cvVersion != null) {
+                        config.cvVersion = Long.valueOf(1);
+                    }
+                    opt = api.findByDomain(config.cvDomain);
+                }
+                if (config.cvVersion != null && opt.isPresent()) {
+                    GsrsControlledVocabularyDTO cvDTO = opt.get();
+                    if (config.cvVersion > Long.valueOf(cvDTO.getVersion()) && !config.terms.isEmpty()) {
+                        List<GsrsVocabularyTermDTO> list = new ArrayList<>();
+                        for (Map.Entry<String, String> entry : config.terms.entrySet()) {
+                            list.add(GsrsVocabularyTermDTO.builder()
+                                .display(entry.getValue())
+                                .value(entry.getKey())
+                                .hidden(false)
+                                .build());
+                        }
+                        cvDTO.setTerms(list);
+                        api.update(cvDTO);
+                    } else {
+                        Map<String, String> tms = new HashMap<String, String>();
+                        for (GsrsVocabularyTermDTO term : new ArrayList<GsrsVocabularyTermDTO>(cvDTO.getTerms())) {
+                            tms.put(new String(term.getValue()), new String(term.getDisplay()));
+                        }
+                        config.terms = tms;
+                    }
+                    config.cvVersion = Long.valueOf(cvDTO.getVersion());
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            } finally{
+                log.debug("finished CV Domain add routine");
+            }
+        }
+    }
+
+    private void updateTermsIfNeeded() {
+        if (config.cvDomain != null && config.cvVersion != null && config.isOutdated()) {
+            TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+            transactionTemplate.setReadOnly(true);
+            transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+            this.config = transactionTemplate.execute(status->{
+                try {
+                    Optional<GsrsControlledVocabularyDTO> opt = api.findByDomain(config.cvDomain);
+                    if (opt.isPresent() && Long.valueOf(opt.get().getVersion()) > config.cvVersion) {
+                        log.debug("Refresh terms from {} CV Domain", config.cvDomain);
+                        CVClassificationsCodeProcessorConfig newConfig = CVClassificationsCodeProcessorConfig.from(this.config);
+                        for (GsrsVocabularyTermDTO term : new ArrayList<GsrsVocabularyTermDTO>(opt.get().getTerms())) {
+                            newConfig.terms.put(String.valueOf(term.getValue()), String.valueOf(term.getDisplay()));
+                        }
+                        newConfig.cvVersion = Long.valueOf(opt.get().getVersion());
+                        return newConfig;
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                return this.config;
+            }).refresh();
+            log.debug("Refresh config");
+        }
+    }
+
+    @Override
+    public void initialize() throws EntityProcessor.FailProcessingException {
+        initializer.getSync();
+    }
+
+    @Override
+    public void prePersist(Code obj) throws EntityProcessor.FailProcessingException {
+        if (config.codeSystem.equals(obj.codeSystem) && obj.code != null && !obj.code.isEmpty()) {
+            updateTermsIfNeeded();
+            String comments = "";
+            if (config.masks.length > 0) {
+                for (int mask: config.masks) {
+                    if (obj.code.length() > mask) {
+                        String display = config.terms.get(obj.code.substring(0, mask));
+                        if (display != null) {
+                            comments = comments + "|" + display;
+                        }
+                    }
+                }
+            }
+            if (!comments.isEmpty()) {
+                comments = comments.substring(1);
+                if (config.prefix != null) {
+                    comments = config.prefix + "|" + comments;
+                }
+                if (!comments.equals(obj.comments)) {
+                    obj.comments = comments;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void preUpdate(Code obj) throws EntityProcessor.FailProcessingException {
+        prePersist(obj);
+    }
+
+    @Override
+    public Class<Code> getEntityClass() {
+        return Code.class;
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/DBClassificationsCodeProcessor.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/DBClassificationsCodeProcessor.java
@@ -1,0 +1,103 @@
+package gsrs.module.substance.processors;
+
+import gsrs.springUtils.StaticContextAccessor;
+import ix.core.EntityProcessor;
+import ix.ginas.models.v1.Code;
+import ix.ginas.models.v1.Reference;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.boot.jdbc.DataSourceBuilder;
+
+/**
+ * This EntityProcessor will create a Classifications comments string
+ * for the Code using Database as the source
+ *
+ * @author Egor Puzanov
+ */
+@Data
+@Slf4j
+public class DBClassificationsCodeProcessor implements EntityProcessor<Code> {
+
+    private final DataSource datasource;
+    private final String codeSystem;
+    private final String query;
+
+    public DBClassificationsCodeProcessor() {
+        this(new HashMap<String, Object>());
+    }
+
+    public DBClassificationsCodeProcessor(Map<String, Object> m) {
+        String dataSourceQualifier = (String) m.get("dataSourceQualifier");
+        if (dataSourceQualifier != null && !dataSourceQualifier.isEmpty()) {
+            this.datasource = StaticContextAccessor.getBeanQualified(DataSource.class, dataSourceQualifier);
+        } else if (m.get("datasource") instanceof Map) {
+            Map<?, ?> dsconfig = (Map<?, ?>) m.get("datasource");
+            this.datasource = DataSourceBuilder.create()
+                                                .url((String)dsconfig.get("url"))
+                                                .username((String)dsconfig.get("username"))
+                                                .password((String)dsconfig.get("password"))
+                                                .build();
+        } else {
+            this.datasource = StaticContextAccessor.getBean(DataSource.class);
+        }
+        this.codeSystem = m.getOrDefault("codeSystem", "").toString();
+        this.query = m.getOrDefault("query", "").toString();
+    }
+
+    @Override
+    public void prePersist(Code obj) throws EntityProcessor.FailProcessingException {
+        if (codeSystem.equals(obj.codeSystem) && obj.code != null && !obj.code.isEmpty()) {
+            try (Connection c = datasource.getConnection()) {
+                try (PreparedStatement s = c.prepareStatement(query)) {
+                    s.setString(1, obj.getCode());
+                    try (ResultSet rs = s.executeQuery()) {
+                        while (rs.next()) {
+                            String value = rs.getString(1);
+                            if (value != null && value.contains("|") && !value.equals(obj.comments)) {
+                                obj.comments = value;
+                                value = rs.getString(2);
+                                if (value != null && value.startsWith("http") && !value.equals(obj.url)) {
+                                   obj.url = value;
+                                }
+                                value = rs.getString(3);
+                                if (value != null && !value.isEmpty() && obj.getReferences().size() == 0) {
+                                    Reference r = new Reference();
+                                    r.docType = value;
+                                    value = rs.getString(4);
+                                    if (value != null && !value.isEmpty()) {
+                                        r.citation = value;
+                                        obj.addReference(r, obj.getOwner());
+                                    }
+                                }
+                            }
+                            break;
+                        }
+                    }
+                }
+            } catch (Exception ex) {
+                log.error(ex.toString());
+            } finally {
+            }
+        }
+    }
+
+    @Override
+    public void preUpdate(Code obj) throws EntityProcessor.FailProcessingException {
+        prePersist(obj);
+    }
+
+    @Override
+    public Class<Code> getEntityClass() {
+        return Code.class;
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/SetAccessCodeProcessor.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/SetAccessCodeProcessor.java
@@ -1,0 +1,74 @@
+package gsrs.module.substance.processors;
+
+import gov.nih.ncats.common.util.CachedSupplier;
+import gsrs.services.GroupService;
+
+import ix.core.EntityProcessor;
+import ix.core.models.Group;
+import ix.ginas.models.v1.Code;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ *
+ * @author Egor Puzanov
+ */
+
+public class SetAccessCodeProcessor implements EntityProcessor<Code>{
+
+    private CachedSupplier initializer = CachedSupplier.runOnceInitializer(this::addGroupsIfNeeded);
+
+    @Autowired
+    private GroupService groupService;
+
+    private Map<String, Map<String, Map<Integer, String>>> with;
+    private Map<String, Set<Group>> codeSystemAccess;
+    private Set<Group> defaultAccess;
+
+    public SetAccessCodeProcessor(Map<String, Map<String, Map<Integer, String>>> with){
+        this.with = with;
+    }
+
+    public void addGroupsIfNeeded(){
+        Map<String, Set<Group>> csa = new HashMap<String, Set<Group>>();
+        for (Map.Entry<String, Map<Integer, String>> e : with.getOrDefault("codeSystemAccess", new HashMap<String, Map<Integer, String>>()).entrySet()) {
+            Set<Group> access = new LinkedHashSet<Group>();
+            Map<Integer, String> group_list = e.getValue();
+            if (group_list != null) {
+                for (String groupName : group_list.values()){
+                    access.add(groupService.registerIfAbsent(groupName));
+                }
+            }
+            csa.put(e.getKey(), access);
+        }
+        if (!csa.containsKey("*")) {
+            csa.put("*", new LinkedHashSet<Group>());
+        }
+        this.defaultAccess = csa.remove("*");
+        this.codeSystemAccess = csa;
+    }
+
+    @Override
+    public void initialize() throws EntityProcessor.FailProcessingException{
+        initializer.getSync();
+    }
+
+    @Override
+    public void prePersist(Code obj) throws EntityProcessor.FailProcessingException {
+        Set<Group> access = codeSystemAccess.getOrDefault(obj.codeSystem, defaultAccess);
+        if(!access.equals(obj.getAccess())){
+            obj.setAccess(access);
+        }
+    }
+
+    @Override
+    public Class<Code> getEntityClass() {
+        return Code.class;
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/UpdateEntityTaskInitializer.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/UpdateEntityTaskInitializer.java
@@ -1,0 +1,219 @@
+package gsrs.module.substance.tasks;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import gov.nih.ncats.common.executors.BlockingSubmitExecutor;
+import gsrs.EntityProcessorFactory;
+import gsrs.scheduledTasks.ScheduledTaskInitializer;
+import gsrs.scheduledTasks.SchedulerPlugin;
+import gsrs.security.AdminService;
+import gsrs.springUtils.StaticContextAccessor;
+import ix.core.EntityProcessor;
+import ix.ginas.models.GinasCommonData;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Used to update any kind of Entity objects
+ *
+ * @author Egor Puzanov
+ *
+ */
+@Slf4j
+@Data
+public class UpdateEntityTaskInitializer extends ScheduledTaskInitializer {
+
+    private Class entityClass;
+    private String description;
+    private String query;
+    private List<Field> resetFields;
+    private List<Field> publicFields;
+
+    @Autowired
+    private EntityProcessorFactory entityProcessorFactory;
+
+    @Autowired
+    private AdminService adminService;
+
+    @Autowired
+    private PlatformTransactionManager platformTransactionManager;
+
+    public UpdateEntityTaskInitializer(
+        @JsonProperty("entityClass") String className,
+        @JsonProperty("description") String description,
+        @JsonProperty("query") String query,
+        @JsonProperty("resetFields") Map<Integer, String> resetFields) {
+        try {
+            this.entityClass = Class.forName(className);
+        } catch (Exception e) {
+            this.entityClass = null;
+        }
+        if (this.entityClass != null) {
+            String simpleClassName = this.entityClass.getSimpleName();
+            this.publicFields = Arrays.asList(this.entityClass.getFields());
+            if (description != null && !description.isEmpty()) {
+                this.description = description;
+            } else {
+                this.description = "Update all " + simpleClassName + " entities in the database";
+            }
+            if (query != null && !query.isEmpty()) {
+                this.query = query;
+            } else {
+                this.query = "select " + ("Structure".equals(simpleClassName) ? "" : "uu") + "id from " + simpleClassName;
+            }
+            if (resetFields != null && !resetFields.isEmpty()) {
+                this.resetFields = resetFields
+                    .values()
+                    .stream()
+                    .map(f->{
+                        Field field = null;
+                        try {
+                            field = this.entityClass.getDeclaredField(f);
+                            field.setAccessible(true);
+                        } catch (Exception e) {}
+                        return field;
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+            } else {
+                this.resetFields = new ArrayList<>();
+            }
+        }
+    }
+
+    @Override
+    public void run(SchedulerPlugin.JobStats stats, SchedulerPlugin.TaskListener l) {
+
+        String entityType = entityClass.getSimpleName();
+        l.message("Initializing " + entityType + " Updater");
+        log.trace("Initializing " + entityType + " Updater");
+
+        l.message("Initializing " + entityType + " Updater: acquiring list");
+
+        ExecutorService executor = BlockingSubmitExecutor.newFixedThreadPool(5, 10);
+        l.message("Initializing " + entityType + " Updater: acquiring user account");
+        Authentication adminAuth = adminService.getAnyAdmin();
+        l.message("Initializing " + entityType + " Updater: starting process");
+        log.trace("starting process");
+
+        try {
+            adminService.runAs(adminAuth, (Runnable) () -> {
+                TransactionTemplate tx = new TransactionTemplate(platformTransactionManager);
+                log.trace("got outer tx " + tx);
+                tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+                try {
+                    processEntities(l);
+                } catch (Exception ex) {
+                    l.message(entityType + " processing error: " + ex.getMessage());
+                }
+            });
+        } catch (Exception ee) {
+            log.error(entityType + " processing error: ", ee);
+            l.message("ERROR:" + ee.getMessage());
+            throw new RuntimeException(ee);
+        }
+
+        l.message("Shutting down executor service");
+        executor.shutdown();
+        try {
+            executor.awaitTermination(1, TimeUnit.DAYS);
+        } catch (InterruptedException e) {
+            //should never happen
+            log.error("Interrupted exception!");
+        }
+        l.message("Task finished");
+        l.complete();
+        //listen.doneProcess();
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    private int makeHash(GinasCommonData entity) {
+        return (resetFields.isEmpty() ? publicFields : resetFields)
+            .stream()
+            .map(f->{
+                try {
+                    return String.valueOf(f.get(entity));
+                } catch (Exception e) {
+                    return "";
+                }
+            })
+            .collect(Collectors.joining()).hashCode();
+    }
+
+    private void processEntities(SchedulerPlugin.TaskListener l){
+        String entityType = entityClass.getSimpleName();
+        log.trace("starting in {} entities", entityType);
+
+        JpaRepository repository = new SimpleJpaRepository(entityClass, StaticContextAccessor.getEntityManagerFor(entityClass));
+        List<UUID> uuids = StaticContextAccessor
+            .getEntityManagerFor(entityClass)
+            .createQuery(query, UUID.class)
+            .getResultList();
+        int total = uuids.size();
+        log.trace("total {} entities: {}", entityType, total);
+        int soFar = 0;
+        for (UUID uuid: uuids) {
+            soFar++;
+            log.trace("processing {} entity with ID {}", entityType, uuid.toString());
+            try {
+                Optional entityOpt = repository.findById(uuid);
+                if (!entityOpt.isPresent()) {
+                    log.info("No {} entity found with ID {}", entityType, uuid.toString());
+                    continue;
+                }
+                GinasCommonData entity = GinasCommonData.class.cast(entityOpt.get());
+                int hash = makeHash(entity);
+                for (Field field : resetFields) {
+                    field.set(entity, null);
+                }
+                EntityProcessor ep = entityProcessorFactory.getCombinedEntityProcessorFor(entityClass.cast(entity));
+                ep.preUpdate(entityClass.cast(entity));
+                if(makeHash(entity) != hash) {
+                    try {
+                        log.trace("resaving {} entity {}", entityType, entity.toString());
+                        TransactionTemplate tx = new TransactionTemplate(platformTransactionManager);
+                        tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+                        tx.setReadOnly(false);
+                        tx.executeWithoutResult(e -> {
+                            log.trace("before saveAndFlush");
+                            GinasCommonData e2 = GinasCommonData.class.cast(StaticContextAccessor.getEntityManagerFor(entityClass).merge(entity));
+                            e2.forceUpdate();
+                            repository.saveAndFlush(entityClass.cast(e2));
+                        });
+                        log.trace("saved {} entity {}", entityType, entity.toString());
+                    } catch (Exception ex) {
+                        log.error("Error during save: {}", ex.getMessage());
+                    }
+                }
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                log.error("Error during processing: {}", ex.getMessage());
+            }
+            l.message(String.format("Processed %d of %d %s entities", soFar, total, entityType));
+        }
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/utils/SplitFunction.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/utils/SplitFunction.java
@@ -1,0 +1,32 @@
+package gsrs.module.substance.utils;
+
+import io.burt.jmespath.Adapter;
+import io.burt.jmespath.JmesPathType;
+import io.burt.jmespath.function.ArgumentConstraints;
+import io.burt.jmespath.function.BaseFunction;
+import io.burt.jmespath.function.FunctionArgument;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SplitFunction extends BaseFunction {
+    public SplitFunction() {
+        super(ArgumentConstraints.listOf(2, 3, ArgumentConstraints.anyValue()));
+    }
+
+    @Override
+    protected <T> T callFunction(Adapter<T> runtime, List<FunctionArgument<T>> arguments) {
+        T subject = arguments.get(0).value();
+        T delimiter = arguments.get(1).value();
+        int limit = -1;
+        if (arguments.size() > 2) {
+            T value = arguments.get(2).value();
+            if (runtime.typeOf(value) == JmesPathType.NUMBER) {
+                limit = (int)runtime.toNumber(value).intValue();
+            }
+        }
+        List<String> lst = Arrays.asList(runtime.toString(subject).split(runtime.toString(delimiter), limit));
+        return runtime.createArray(lst.stream().map(p->runtime.createString(p)).collect(Collectors.toList()));
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/utils/UniqueFunction.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/utils/UniqueFunction.java
@@ -1,0 +1,22 @@
+package gsrs.module.substance.utils;
+
+import io.burt.jmespath.Adapter;
+import io.burt.jmespath.JmesPathType;
+import io.burt.jmespath.function.ArgumentConstraints;
+import io.burt.jmespath.function.BaseFunction;
+import io.burt.jmespath.function.FunctionArgument;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class UniqueFunction extends BaseFunction {
+    public UniqueFunction() {
+        super(ArgumentConstraints.typeOf(JmesPathType.ARRAY));
+    }
+
+    @Override
+    protected <T> T callFunction(Adapter<T> runtime, List<FunctionArgument<T>> arguments) {
+        T array = arguments.get(0).value();
+        return runtime.createArray(runtime.toList(array).stream().distinct().collect(Collectors.toList()));
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/JmespathValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/JmespathValidator.java
@@ -1,0 +1,145 @@
+package ix.ginas.utils.validation.validators;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import gsrs.validator.ValidatorConfig;
+import gsrs.module.substance.utils.SplitFunction;
+import gsrs.module.substance.utils.UniqueFunction;
+
+import io.burt.jmespath.JmesPath;
+import io.burt.jmespath.Expression;
+import io.burt.jmespath.RuntimeConfiguration;
+import io.burt.jmespath.function.FunctionRegistry;
+import io.burt.jmespath.jackson.JacksonRuntime;
+
+import ix.core.controllers.EntityFactory;
+import ix.core.validator.GinasProcessingMessage;
+import ix.core.validator.ValidatorCallback;
+import ix.ginas.models.v1.Substance;
+import ix.ginas.utils.validation.AbstractValidatorPlugin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Created by epuzanov on 2/26/24.
+ */
+@Slf4j
+public class JmespathValidator extends AbstractValidatorPlugin<Substance>{
+
+    private List<ValidatorExpression> expressions = new ArrayList<ValidatorExpression>();
+    private final ObjectWriter writer = EntityFactory.EntityMapper.FULL_ENTITY_MAPPER().writer();
+
+    private class ValidatorExpression {
+        private final GinasProcessingMessage.MESSAGE_TYPE messageType;
+        private final String messageId;
+        private final String messageTemplate;
+        private final String rawExpression;
+        private final Expression<JsonNode> expression;
+
+        public ValidatorExpression(Map<String, String> m) {
+            FunctionRegistry customFunctions = FunctionRegistry.defaultRegistry().extend(
+                                                           new SplitFunction(),
+                                                           new UniqueFunction());
+            RuntimeConfiguration configuration = new RuntimeConfiguration.Builder()
+                                       .withFunctionRegistry(customFunctions)
+                                       .build();
+            JmesPath<JsonNode> jmespath = new JacksonRuntime(configuration);
+            this.messageType = GinasProcessingMessage.MESSAGE_TYPE.valueOf(m.getOrDefault("messageType", "NOTICE"));
+            this.messageTemplate = m.get("messageTemplate");
+            this.messageId = m.getOrDefault("messageId", this.messageType.toString().substring(0,1)
+                                    + String.valueOf("JmespathValidator".hashCode()).substring(2,5)
+                                    + String.valueOf(this.messageTemplate.hashCode()).substring(1,5));
+            this.rawExpression = m.get("expression");
+            this.expression = (Expression<JsonNode>) jmespath.compile(this.rawExpression);
+        }
+
+        public boolean isValid() {
+            if (messageTemplate == null || expression == null) {
+                return false;
+            }
+            return true;
+        }
+
+        public void validate(JsonNode tree, ValidatorCallback callback) {
+            log.debug("Validation Expression: " + rawExpression);
+            JsonNode results = expression.search(tree);
+            log.debug("Validation Results: " + results.toString());
+            if (results != null && !results.isNull() && !(results.isArray() && results.size() < 1) && !(results.isBoolean() && !results.asBoolean())) {
+                if (!results.isArray()) {
+                    results = (JsonNode) new ObjectMapper().createArrayNode().add(results);
+                }
+                String[] args = StreamSupport.stream(results.spliterator(), false)
+                                            .map(JsonNode::asText)
+                                            .toArray(String[]::new);
+                String msg = String.format(messageTemplate, args);
+                log.debug("Validation Message: " + messageId + " " + msg);
+                callback.addMessage(new GinasProcessingMessage(messageType, msg, messageId));
+            }
+        }
+    }
+
+    @Override
+    public boolean supports(Substance newValue, Substance oldValue, ValidatorConfig.METHOD_TYPE methodType) {
+        return methodType != ValidatorConfig.METHOD_TYPE.BATCH;
+    }
+
+    @Override
+    public void validate(Substance objnew, Substance objold, ValidatorCallback callback) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            JsonNode tree = mapper.readTree("{\"new\":" + writer.writeValueAsString(objnew) + ",\"old\":" + writer.writeValueAsString(objold) + "}");
+            log.debug("Validation Tree: " + tree.toString());
+            updateReferences(tree.get("new"));
+            updateReferences(tree.get("old"));
+            for (ValidatorExpression expression: expressions) {
+                expression.validate(tree, callback);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void setExpressions(LinkedHashMap<Integer, Map<String, String>> expressions) {
+        this.expressions.clear();
+        for (Map<String, String> expression: expressions.values()) {
+            ValidatorExpression expr = new ValidatorExpression(expression);
+            if (expr.isValid()) {
+                this.expressions.add(expr);
+            }
+        }
+    }
+
+    private void updateReferences(JsonNode tree) {
+        if (tree == null || tree.isNull()) return;
+        ArrayNode references = (ArrayNode)tree.at("/references");
+        Map<String, Integer> refMap = new HashMap<>();
+        for (int i = 0; i < references.size(); i++) {
+            refMap.put(references.get(i).get("uuid").textValue(), i);
+        }
+        for (JsonNode refsNode: tree.findValues("references")) {
+            if (refsNode.isArray()) {
+                ArrayNode refs = (ArrayNode) refsNode;
+                for (int i = 0; i < refs.size(); i++) {
+                    JsonNode ref = refs.get(i);
+                    if (ref.isTextual()) {
+                        Integer index = refMap.get(ref.asText());
+                        if(index !=null) {
+                            refs.set(i, references.get(index));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR add following GSRS extensions from https://github.com/epuzanov/gsrs-ep-substance-extension repository.

### gsrs.module.substance.exporters.GsrsApiExporterFactory
The GsrsApiExporter can be used for the exporting of the substances directly to anothe GSRS instance.

#### Dependencies
* org.apache.httpcomponents.httpclient

#### Configuration

```
ix.ginas.export.exporterfactories.substances += {
    "exporterFactoryClass": "gsrs.module.substance.exporters.GsrsApiExporterFactory",
    "parameters": {
        "format": {
            "extension": "gsrsapi",
            "displayName": "Send to ..."
        },
        "headers": {
            #"auth-username": "admin",
            #"auth-password": "admin",
            #"AUTHENTICATION_HEADER_NAME_EMAIL": "{{user.email}}",
            "auth-username": "{{user.name}}",
            "auth-key": "{{user.apikey}}"

        },
        "baseUrl": "https://public.gsrs.test/api/v1/substances",
        "timeout": 120000,
        "trustAllCerts": false,
        "allowedRole": "Approver",
        "newAuditor": "admin",
        "changeReason": "{{changeReason}} (Version {{version}})",
        "validate": true
    }
}
```

### gsrs.module.substance.exporters.JmespathSpreadsheetExporterFactory
The JmespathSpreadsheetExporter can to be used for exporting substances to Excel file with custom defined fields. It uses Jmespath expressions to select values from substances json.

#### Dependencies
* io.burt.jmespath-jackson

#### Configuration

```
ix.ginas.export.exporterfactories.substances += {
    "exporterFactoryClass": "gsrs.module.substance.exporters.JmespathSpreadsheetExporterFactory",
    "parameters": {
        "format": {
            "extension": "custom.xlsx",
            "displayName": "Custom Report (xlsx) File"
        },
        "columnExpressions": [
            {"name":"UUID", "expression":"uuid"},
            {"name":"NAME", "expression":"_name"},
            {"name":"APPROVAL_ID", "expression":"_approvalIDDisplay"},
            {"name":"SMILES", "expression":"structure.smiles"},
            {"name":"FORMULA", "expression":"structure.formula"},
            {"name":"SUBSTANCE_TYPE", "expression":"substanceClass"},
            {"name":"STD_INCHIKEY", "expression":"structure.inchikey"},
            {"name":"STD_INCHIKEY_FORMATTED", "expression":"structure.inchikeyf"},
            {"name":"CAS", "expression":"codes[?codeSystem=='CAS'].code","delimiter":"|"},
            {"name":"EC", "expression":"codes[?codeSystem=='ECHA (EC/EINECS)'].code"},
            {"name":"ITIS", "expression":"codes[?codeSystem=='ITIS'].code"},
            {"name":"NCBI", "expression":"codes[?codeSystem=='NCBI TAXONOMY'].code"},
            {"name":"USDA_PLANTS", "expression":"codes[?codeSystem=='USDA PLANTS'].code"},
            {"name":"INN", "expression":"codes[?codeSystem=='INN'].code"},
            {"name":"NCI_THESAURUS", "expression":"codes[?codeSystem=='NCI_THESAURUS'].code"},
            {"name":"RXCUI", "expression":"codes[?codeSystem=='RXCUI'].code"},
            {"name":"PUBCHEM", "expression":"codes[?codeSystem=='PUBCHEM'].code"},
            {"name":"MPNS", "expression":"codes[?codeSystem=='MPNS'].code"},
            {"name":"GRIN", "expression":"codes[?codeSystem=='GRIN'].code"},
            {"name":"INGREDIENT_TYPE", "expression":"relationships[?contains(['IONIC MOIETY', 'MOLECULAR FRAGMENT', 'UNSPECIFIED INGREDIENT', 'SPECIFIED SUBSTANCE'], type)].type || 'INGREDIENT SUBSTANCE'"},
            {"name":"PROTEIN_SEQUENCE", "expression":"protein.subunits[].sequence", "delimiter":"|"},
            {"name":"NUCLEIC_ACID_SEQUENCE", "expression":"nucleicAcid.subunits[].sequence", "delimiter":"|"},
            {"name":"RECORD_ACCESS_GROUPS", "expression":"access", "delimiter":"|"},
            {"name":"LAST_EDITED", "expression":"lastEdited", "datetime":"yyyy-MM-dd HH:mm:ss"}
        ]
    }
}
```

### gsrs.module.substance.indexers.JmespathIndexValueMaker
The JmespathIndexvalueMaker canbe used for creating of the custom indexes. It uses Jmespath expressions to select values from substances json.

#### Dependencies
* io.burt.jmespath-jackson

#### Configuration

```
gsrs.indexers.list += {
    "class" = "ix.ginas.models.v1.Substance",
    "indexer" = "gsrs.module.substance.indexers.JmespathIndexValueMaker",
    "parameters" = {
        "expressions" = [
            {"index":"ATC Level 1", "expression": "codes[?codeSystem=='WHO-ATC' && starts_with(comments, 'ATC|')].comments", "regex":"ATC.([^\\Q|\\E]*).*"},
            {"index":"ATC Level 2", "expression": "codes[?codeSystem=='WHO-ATC' && starts_with(comments, 'ATC|')].comments", "regex":"ATC.[^\\Q|\\E]*.([^\\Q|\\E]*).*"},
            {"index":"ATC Level 3", "expression": "codes[?codeSystem=='WHO-ATC' && starts_with(comments, 'ATC|')].comments", "regex":"ATC.[^\\Q|\\E]*.[^\\Q|\\E]*.([^\\Q|\\E]*).*"},
            {"index":"ATC Level 4", "expression": "codes[?codeSystem=='WHO-ATC' && starts_with(comments, 'ATC|')].comments", "regex":"ATC.[^\\Q|\\E]*.[^\\Q|\\E]*.[^\\Q|\\E]*.([^\\Q|\\E]*).*"},
            {"index":"Naming Orgs", "expression": "names[?type=='of'].nameOrgs[]"},
            {"index":"Name TypeLang", "expression": "names[?type=='of'].languages[].join('_', ['of', @])"},
            {"index":"Name TypeLang", "expression": "names[?type=='sys'].languages[].join('_', ['sys', @])"},
            {"index":"Name TypeLang", "expression": "names[?type=='cn'].languages[].join('_', ['cn', @])"},
            {"index":"Name TypeLang", "expression": "names[?type=='bn'].languages[].join('_', ['bn', @])"},
            {"index":"Name TypeLang", "expression": "names[?type=='cd'].languages[].join('_', ['od', @])"},
            {"index":"Reference Tags", "expression": "references[].tags[]"},
            {"index":"Molecular Weight", "expression": "properties[?starts_with(name, 'MOL_WEIGHT')].floor(value.average)", "ranges": "0 200 400 600 800 1000", "format": "%1$.0f", "sortable":true},
            {"index":"root_structure_mwt", "type": "Double", "expression": "properties[?starts_with(name, 'MOL_WEIGHT')].value.average", "sortable":true},
            {"index":"Deprecated", "expression": "[map(&'Deprecated',[deprecated][?@]),'Not Deprecated'][] | @[0]"}
        ]
    }
}
```

### gsrs.module.substance.processors.CVClassificationsCodeProcessor
The CVClassificationsCodeProcessor can be used for creating the comment string for classification codes.

#### Configuration

```
gsrs.entityProcessors += {
    "entityClassName" = "ix.ginas.models.v1.Code",
    "processor" = "gsrs.module.substance.processors.CVClassificationsCodeProcessor",
    "with" = {
        "codeSystem" = "WHO-ATC",
        "prefix" = "ATC",
        "masks" = [1, 3, 4, 5],
        "terms" = {
            "C" = "Cardiovascular system",
            "C01" = "Cardiac therapy",
            "C01E" = "Other cardiac preparations",
            "C01EB" = "Other cardiac preparations",
            "C01EB16" = "Ibuprofen",
            "G" = "Genito urinary system and sex hormones",
            "G02" = "Other gynecologicals",
            "G02C" = "Other gynecologicals",
            "G02CC" = "Antiinflammatory products for vaginal administration",
            "G02CC01" = "Ibuprofen",
            "M" = "Musculo-skeletal system",
            "M01" = "Antiinflammatory and antirheumatic products",
            "M01A" = "Antiinflammatory and antirheumatic products, non-steroids",
            "M01AE" = "Propionic acid derivatives",
            "M01AE01" = "Ibuprofen",
            "M01AE51" = "Ibuprofen, combinations",
            "N" = "Nervous system",
            "N02" = "Analgesics",
            "N02A" = "Opioids",
            "N02AJ" = "Opioids in combination with non-opioid analgesics",
            "N02AJ08" = "Codeine and Ibuprofen",
            "N02AJ19" = "Oxycodone and Ibuprofen",
            "N04" = "Anti-parkinson",
            "N04B" = "Dopaminergic agents",
            "N04BC" = "Dopamine agonists",
            "N04BC05" = "Pramipexole"
        }
    }
}
```

#### Alternative Configuration 1
Include Veterinary ATC codes dictionary from JSON file include LEVEL 5 codes.

```
gsrs.entityProcessors += {
    "entityClassName" = "ix.ginas.models.v1.Code",
    "processor" = "gsrs.module.substance.processors.CVClassificationsCodeProcessor",
    "with" = {
        "codeSystem" = "WHO-VATC",
        "prefix" = "VATC",
        "masks" = [2, 4, 5, 6, 8],
        "terms" = { include "vatcCodes.json" }
    }
}
```

#### Alternative Configuration 2
Use the GSRS CV for storing ATC Classification information. And initially populate the CV from the JSON file if the cvVersion is greater then the version of the CV Domain.

```
gsrs.entityProcessors += {
    "entityClassName" = "ix.ginas.models.v1.Code",
    "processor" = "gsrs.module.substance.processors.CVClassificationsCodeProcessor",
    "with" = {
        "codeSystem" = "WHO-ATC",
        "prefix" = "ATC",
        "masks" = [1, 3, 4, 5],
        "cvDomain": "CLASSIFICATION_WHO_ATC",
        "cvVersion": 2,
        "terms" = { include "atcCodes.json" }
    }
}
```

### gsrs.module.substance.processors.DBClassificationsCodeProcessor
The DBClassificationsCodeProcessor can be used for creating the comment string for classification codes using SQL database as the source. The query must return 4 fields.
The first field contains COMMENTS text, the second field contains URL, the third field contains DOC_TYPE of the Reference and the fourth field contains CITATION of the Reference.
The second, third and fourth fields can return NULL values.

#### Configuration

```
gsrs.entityProcessors += {
    "entityClassName" = "ix.ginas.models.v1.Code",
    "processor" = "gsrs.module.substance.processors.DBClassificationsCodeProcessor",
    "with" = {
        "codeSystem" = "PV",
        "query" = """SELECT
'ROOT|' || SUB_CATEGORY || '|' || CLASSIFICATION,
URL,
REF_DOC_TYPE,
REF_CITATION
FROM CLASSIFICATIONS
WHERE CODE = ?
""",
        "datasource" = {
            "url" = "jdbc:oracle:thin:@//db-server:1521/CLASSIFICATIONS",
            "username" = "gsrs",
            "password" = "somepassword"
        }
    }
}
```

### gsrs.module.substance.processors.SetAccessCodeProcessor
The SetAccessCodeProcessor can be used to force the access value for the specific code system.

#### Configuration

```
gsrs.entityProcessors += {
    "class":"ix.ginas.models.v1.Code",
    "processor":"gsrs.module.substance.processors.SetAccessCodeProcessor",
    "with":{
        "codeSystemAccess": {
            "BDNUM": ["protected"],
            "*": []
        }
    }
}
```

### gsrs.module.substance.tasks.UpdateEntityTaskInitializer
The UpdateEntityTaskInitializer task can be used for updating attributes from any Entity class in the GSRS
The optional parameter "query" can be used for granular selection of the objects.
The optional parameter "resetFields" can be used to nullify specified fields before invoking the "preUpdate" method.

#### Configuration

```
gsrs.scheduled-tasks.list+= {
    "scheduledTaskClass" : "gsrs.module.substance.tasks.UpdateEntityTaskInitializer",
    "parameters" : {
        "entityClass": "ix.ginas.models.v1.Code",
        "query": "select uuid from Code where codeSystem = 'CAS'",
        "resetFields": ["url"],
        "autorun": false
    }
}
```

### ix.ginas.utils.validation.validators.JmespathValidator
The JmespathValidator can to be used for creating the custom GSRS validations rules. It uses Jmespath expressions to validate the substances json.

#### Dependencies
* io.burt.jmespath-jackson

#### Configuration

```
gsrs.validators.substances += {
    "validatorClass" = "ix.ginas.utils.validation.validators.JmespathValidator",
    "newObjClass" = "ix.ginas.models.v1.Substance",
    "configClass" = "SubstanceValidatorConfig",
    "parameters"= {
        "expressions" = [
            {"messageType": "ERROR", "messageTemplate": "Only single %s Code allowed.", "expression": "new.codes[?type=='PRIMARY' && codeSystem=='MyCodeSystem'].codeSystem | [1]"},
            {"messageType": "ERROR", "messageTemplate": "The MyCodeSystem Code can not be changed.", "expression": "values(@)[*].codes[?type=='PRIMARY' && codeSystem=='MyCodeSystem'].code | [] | [0] != [1] && [1] != `null`"},
            {"messageType": "ERROR", "messageTemplate": "More then One Note with Public Reference is not allowed.", "expression": "new.notes[?length(references[? publicDomain==`true` && contains(tags, 'PUBLIC_DOMAIN_RELEASE') && length(access) == `0`]) > `0`].note | [1]"}.
            {"messageType": "ERROR", "messageTemplate": "Non Public records must have a PUBLIC DOMAIN reference without a '%s' tag", "expression": "to_array(new)[?length(access) > `0`].references[] | [? publicDomain==`true` && contains(tags, 'PUBLIC_DOMAIN_RELEASE') && length(access) == `0`].tags[0]"}
        ]
    }
}
```
