### PR TITLE
False positive by CodeUniquenessValidator if non-primary code exists

### DIFF
--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/repository/SubstanceRepository.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/repository/SubstanceRepository.java
@@ -66,6 +66,8 @@ public interface SubstanceRepository extends GsrsVersionedRepository<Substance, 
     List<SubstanceSummary> findByNames_StdNameIgnoreCase(String stdName);
 
     List<SubstanceSummary> findByCodes_CodeIgnoreCase(String code);
+
+    @Query("select s from Substance s join s.codes c where c.code = ?1 and c.codeSystem = ?2 and c.type = 'PRIMARY'")
     List<SubstanceSummary> findByCodes_CodeAndCodes_CodeSystem(String code, String codeSystem);
 
     Substance findByModifications_Uuid(UUID uuid);


### PR DESCRIPTION
This PR fixed the false positive by CodeUniquenessValidator if non-primary code already exists.