### PR TITLE
SQLExporter and ScheduledExportTask extensions

### DIFF
--- a/gsrs-module-substances-core/pom.xml
+++ b/gsrs-module-substances-core/pom.xml
@@ -311,6 +311,36 @@
             <version>4.5.14</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.26.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-vfs2</artifactId>
+            <version>2.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+            <version>0.1.55</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>net.coobird</groupId>
             <artifactId>thumbnailator</artifactId>
             <version>0.4.19</version>

--- a/gsrs-module-substances-core/pom.xml
+++ b/gsrs-module-substances-core/pom.xml
@@ -313,17 +313,22 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.0</version>
+            <version>1.26.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.11.0</version>
+            <version>1.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-vfs2</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.11.1</version>
         </dependency>
         <dependency>
             <groupId>com.jcraft</groupId>

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporter.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporter.java
@@ -123,7 +123,8 @@ public class SQLExporter implements Exporter<Substance> {
                 .setHeader(String.valueOf(m.getOrDefault("header", "")).isEmpty() ? null : String.valueOf(m.get("header")).trim().split(delimiter))
                 .setQuote(m.get("quoteChar") != null ? Character.valueOf(String.valueOf(m.get("quoteChar")).charAt(0)) : format.getQuoteCharacter())
                 .setQuoteMode(m.get("quoteMode") != null ? QuoteMode.valueOf(String.valueOf(m.get("quoteMode"))) : format.getQuoteMode())
-                .setEscape(m.get("escapeChar") != null ? Character.valueOf(String.valueOf(m.get("escapeChar")).charAt(0)) : format.getEscapeCharacter())
+                 //MM change to prevent StringIndexOutOfBoundsException
+                .setEscape(m.get("escapeChar") != null  && ((String)m.get("escapeChar")).length()> 0 ? Character.valueOf(String.valueOf(m.get("escapeChar")).charAt(0)) : format.getEscapeCharacter())
                 .setNullString((String) m.getOrDefault("nullString", format.getNullString()))
                 .setRecordSeparator((String) m.getOrDefault("recordSeparator", format.getRecordSeparator()))
                 .get();

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporter.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporter.java
@@ -124,7 +124,7 @@ public class SQLExporter implements Exporter<Substance> {
                 .setHeader(String.valueOf(m.getOrDefault("header", "")).isEmpty() ? null : String.valueOf(m.get("header")).trim().split(delimiter))
                 .setQuote(m.get("quoteChar") != null ? Character.valueOf(String.valueOf(m.get("quoteChar")).charAt(0)) : format.getQuoteCharacter())
                 .setQuoteMode(m.get("quoteMode") != null ? QuoteMode.valueOf(String.valueOf(m.get("quoteMode"))) : format.getQuoteMode())
-                .setEscape(m.get("escapeChar") != null ? Character.valueOf(String.valueOf(m.get("escapeChar")).charAt(0)) : format.getEscapeCharacter())
+                .setEscape(m.get("escapeChar") != null && String.valueOf(m.get("escapeChar")).length()>0 ? Character.valueOf(String.valueOf(m.get("escapeChar")).charAt(0)) : format.getEscapeCharacter())
                 .setNullString((String) m.getOrDefault("nullString", format.getNullString()))
                 .setRecordSeparator((String) m.getOrDefault("recordSeparator", format.getRecordSeparator()))
                 .build();

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporter.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporter.java
@@ -124,7 +124,7 @@ public class SQLExporter implements Exporter<Substance> {
                 .setQuote(m.get("quoteChar") != null ? Character.valueOf(String.valueOf(m.get("quoteChar")).charAt(0)) : format.getQuoteCharacter())
                 .setQuoteMode(m.get("quoteMode") != null ? QuoteMode.valueOf(String.valueOf(m.get("quoteMode"))) : format.getQuoteMode())
                  //MM change to prevent StringIndexOutOfBoundsException
-                .setEscape(m.get("escapeChar") != null  && ((String)m.get("escapeChar")).length()> 0 ? Character.valueOf(String.valueOf(m.get("escapeChar")).charAt(0)) : format.getEscapeCharacter())
+                .setEscape(m.get("escapeChar") != null  && String.valueOf(m.get("escapeChar")).length()> 0 ? Character.valueOf(String.valueOf(m.get("escapeChar")).charAt(0)) : format.getEscapeCharacter())
                 .setNullString((String) m.getOrDefault("nullString", format.getNullString()))
                 .setRecordSeparator((String) m.getOrDefault("recordSeparator", format.getRecordSeparator()))
                 .get();

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporter.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporter.java
@@ -1,0 +1,471 @@
+package gsrs.module.substance.exporters;
+
+import gsrs.springUtils.StaticContextAccessor;
+
+import ix.ginas.exporters.Exporter;
+import ix.ginas.models.v1.Substance;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.sql.DataSource;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorOutputStream;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.csv.QuoteMode;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+
+/**
+ * Substance Exporter that used SQL to get data from GSRS.
+ * Created by Egor Puzanov
+ */
+@Slf4j
+public class SQLExporter implements Exporter<Substance> {
+
+    private OutputStream out;
+    private String extension;
+    private StringConverter stringConverter;
+    private List<EntryConfig> files;
+    private File tmpdir;
+    private Lock lock = new ReentrantLock();
+
+    public interface StringConverter {
+        String toFormat(String format, String str);
+    }
+
+    public static abstract class AbstractStringConverter implements StringConverter {
+        protected static String replaceFromLists(String str, String[] searchList, String[] replaceList) {
+            if(str == null){
+                return null;
+            }
+            StringBuilder sb = new StringBuilder(str);
+            for (int i = 0; i < searchList.length; i++)
+            {
+                String key = searchList[i];
+                if ("".equals(key)) {
+                    continue;
+                }
+                String value = replaceList[i];
+                int start = sb.indexOf(key, 0);
+                while (start > -1) {
+                    int end = start + key.length();
+                    int nextSearchStart = start + value.length();
+                    sb.replace(start, end, value);
+                    start = sb.indexOf(key, nextSearchStart);
+                }
+            }
+            return sb.toString();
+        }
+
+        @Override
+        public String toFormat(String format, String str){
+            return str;
+        }
+    }
+
+    public static class DefaultStringConverter extends AbstractStringConverter {
+        public String toFormat(String format, String str) {
+            return str;
+        }
+    }
+
+    @Data
+    public static class EntryConfig {
+        private final String name;
+        private final String sql;
+        private final Charset encoding;
+        private final CSVFormat format;
+
+        public EntryConfig (Map<String, Object> m) {
+            this.name = (String) m.get("name");
+            this.sql = (String) m.get("sql");
+            this.encoding = Charset.forName(String.valueOf(m.getOrDefault("encoding", "UTF-8")));
+            CSVFormat format =  CSVFormat.valueOf(String.valueOf(m.getOrDefault("format", "Default")));
+            String delimiter = String.valueOf(m.getOrDefault("delimiter", format.getDelimiterString()));
+            this.format = format.builder()
+                .setDelimiter(delimiter)
+                .setHeader(String.valueOf(m.getOrDefault("header", "")).isEmpty() ? null : String.valueOf(m.get("header")).trim().split(delimiter))
+                .setQuote(m.get("quoteChar") != null ? Character.valueOf(String.valueOf(m.get("quoteChar")).charAt(0)) : format.getQuoteCharacter())
+                .setQuoteMode(m.get("quoteMode") != null ? QuoteMode.valueOf(String.valueOf(m.get("quoteMode"))) : format.getQuoteMode())
+                .setEscape(m.get("escapeChar") != null ? Character.valueOf(String.valueOf(m.get("escapeChar")).charAt(0)) : format.getEscapeCharacter())
+                .setNullString((String) m.getOrDefault("nullString", format.getNullString()))
+                .setRecordSeparator((String) m.getOrDefault("recordSeparator", format.getRecordSeparator()))
+                .build();
+        }
+    }
+
+    private SQLExporter(Builder builder){
+        this.out = builder.out;
+        this.extension = builder.extension;
+        this.stringConverter = builder.stringConverter;
+        this.files = builder.files;
+        this.tmpdir = builder.tmpdir;
+    }
+
+    @Override
+    public void exportForEachAndClose(Iterator<Substance> it) throws IOException{
+        this.close();
+    }
+
+    @Override
+    public void export(Substance s) throws IOException {
+    }
+
+    @Override
+    public void close() throws IOException {
+        try (Connection c = getConnection()) {
+            log.debug("Establishing SQL connection");
+            lock.lock();
+            for (EntryConfig entry : files) {
+                //log.debug("EntryConfig: " + entry.getName() + " " + entry.getSql());
+                try (PreparedStatement s = c.prepareStatement(entry.getSql())){
+                    try (ResultSet rs = s.executeQuery()) {
+                        makeCsvFile(entry, rs);
+                    }
+                }
+            }
+            compressIfNeeded();
+        } catch (Exception e) {
+            log.error("Error writing SQL export", e);
+        } finally {
+            lock.unlock();
+            log.debug("Closed SQL Connection");
+        }
+        tmpdir.delete();
+        this.out.close();
+    }
+
+    private Connection getConnection() throws SQLException {
+        DataSource dataSource = StaticContextAccessor.getBean(DataSource.class);
+        if (dataSource == null) {
+            log.error("data source is null!");
+            return null;
+        }
+        return dataSource.getConnection();
+    }
+
+    private void makeCsvFile(EntryConfig entry, ResultSet rs) throws IOException {
+        ResultSetMetaData metadata = null;
+        String value = "";
+        String part_value = "";
+        int ccount = 0;
+        List<String> cast_fields = new ArrayList<String>();
+        File file = new File(tmpdir, entry.getName());
+        file.getParentFile().mkdirs();
+
+        try (
+            FileWriter fileWriter = new FileWriter(file);
+            CSVPrinter csvPrinter = new CSVPrinter(fileWriter, entry.getFormat());
+        ) {
+            metadata = rs.getMetaData();
+            ccount = metadata.getColumnCount();
+            // Output header
+            for (int i = 1; i <= ccount; i++) {
+                value = metadata.getColumnName(i).toUpperCase();
+                if (value.startsWith("CAST_TO_PART")) {
+                    cast_fields.add("PART");
+                    continue;
+                } else if (value.startsWith("CAST_TO_")) {
+                    cast_fields.add(value.substring(8, 12));
+                    value = value.substring(13);
+                } else {
+                    cast_fields.add("NONE");
+                }
+            }
+
+            // Output each row
+            while (rs.next()) {
+                part_value = "";
+                // log.debug("Processing row: " + rs.getString(1));
+                for (int i = 0; i < ccount; i++) {
+                    value = rs.getString(i + 1);
+                    if (cast_fields.get(i) == "PART") {
+                        if (value == null) {
+                            part_value = "";
+                        } else {
+                            part_value = value;
+                        }
+                        continue;
+                    }
+                    if (!"".equals(part_value)) {
+                        if (value == null) {
+                            value = "";
+                        }
+                        value = value + part_value;
+                        part_value = "";
+                    }
+                    csvPrinter.print(stringConverter.toFormat(cast_fields.get(i), value));
+                }
+                csvPrinter.println();
+            }
+        } catch (Exception e) {
+            log.error("Exception:", e);
+        }
+    }
+
+    private void compressIfNeeded() throws ArchiveException, CompressorException, IOException {
+        byte[] buffer = new byte[1024];
+        int len;
+        String archiverName = null;
+        String compressorName = null;
+        File exportFile = null;
+        String[] tmpFiles = tmpdir.list();
+
+        if (tmpFiles.length < 1) {
+            return;
+        }
+
+        exportFile = new File(tmpdir, tmpFiles[0]);
+        boolean isSingleRegularFile = tmpFiles.length == 1 && Files.isRegularFile(exportFile.toPath(), LinkOption.NOFOLLOW_LINKS);
+
+        switch ((extension.contains(".") ? extension.substring(extension.lastIndexOf(".") + 1) : extension).toLowerCase()) {
+            case "zip":
+                archiverName = ArchiveStreamFactory.ZIP;
+                break;
+            case "jar":
+                archiverName = ArchiveStreamFactory.JAR;
+                break;
+            case "7z":
+                archiverName = ArchiveStreamFactory.SEVEN_Z;
+                break;
+            case "ar":
+                archiverName = ArchiveStreamFactory.AR;
+                break;
+            case "arj":
+                archiverName = ArchiveStreamFactory.ARJ;
+                break;
+            case "tar":
+                archiverName = ArchiveStreamFactory.TAR;
+                break;
+            case "cpio":
+                archiverName = ArchiveStreamFactory.CPIO;
+                break;
+            case "gz": case "gzip":
+                compressorName = CompressorStreamFactory.GZIP;
+                break;
+            case "bz2": case "bzip2":
+                compressorName = CompressorStreamFactory.BZIP2;
+                break;
+            case "br":
+                compressorName = CompressorStreamFactory.BROTLI;
+                break;
+            case "xz":
+                compressorName = CompressorStreamFactory.XZ;
+                break;
+            case "z":
+                compressorName = CompressorStreamFactory.Z;
+                break;
+            case "cpgz":
+                archiverName = ArchiveStreamFactory.CPIO;
+                compressorName = CompressorStreamFactory.GZIP;
+                break;
+            case "tgz":
+                archiverName = ArchiveStreamFactory.TAR;
+                compressorName = CompressorStreamFactory.GZIP;
+                break;
+            case "cpbz2":
+                archiverName = ArchiveStreamFactory.CPIO;
+                compressorName = CompressorStreamFactory.BZIP2;
+                break;
+            case "tbz2":
+                archiverName = ArchiveStreamFactory.TAR;
+                compressorName = CompressorStreamFactory.BZIP2;
+                break;
+            case "xlsx":
+                archiverName = "xlsx";
+                break;
+            default:
+                if (!isSingleRegularFile) {
+                    archiverName = ArchiveStreamFactory.ZIP;
+                }
+        }
+
+        if (compressorName != null && archiverName == null && !isSingleRegularFile) {
+            if (extension.toLowerCase().contains(".cpio.")) {
+                archiverName = ArchiveStreamFactory.CPIO;
+            } else {
+                archiverName = ArchiveStreamFactory.TAR;
+            }
+        }
+
+        if ("xlsx".equals(archiverName)) {
+            Workbook workbook = new XSSFWorkbook();
+            for (EntryConfig entry : files) {
+                File file = new File(tmpdir, entry.getName());
+                if (!file.isFile()) {
+                    continue;
+                }
+                Sheet sheet = workbook.createSheet(entry.getName());
+                CSVParser parser = CSVParser.parse(
+                    new FileReader(file),
+                    entry.getFormat());
+                for (CSVRecord csvRecord : parser) {
+                    Row row = sheet.createRow((int) csvRecord.getRecordNumber() - 1);
+                    for (int i = 0; i < csvRecord.size(); i++) {
+                        Cell cell = row.createCell(i);
+                        cell.setCellValue(csvRecord.get(i));
+                    }
+                }
+                file.delete();
+            }
+            try {
+                workbook.write(this.out);
+            } catch (Exception e) {
+                log.error("Exception:", e);
+            }
+            exportFile = null;
+            archiverName = null;
+        }
+
+        if (archiverName != null) {
+            exportFile = new File(tmpdir, "export.arcTmp");
+            try (
+                OutputStream fos = new FileOutputStream(exportFile);
+                ArchiveOutputStream aos = new ArchiveStreamFactory().createArchiveOutputStream(archiverName, fos);
+            ) {
+                for (EntryConfig entry : files) {
+                    File file = new File(tmpdir, entry.getName());
+                    if (!file.isFile()) {
+                        continue;
+                    }
+                    aos.putArchiveEntry(
+                        aos.createArchiveEntry(
+                            file,
+                            entry.getName()));
+                    try (InputStream is = new FileInputStream(file)) {
+                        while (( len = is.read(buffer)) > 0) {
+                            aos.write(buffer, 0, len);
+                        }
+                    }
+                    aos.closeArchiveEntry();
+                    file.delete();
+                }
+            }
+        }
+
+        if (compressorName != null) {
+            try (
+                InputStream is = new FileInputStream(exportFile);
+                CompressorOutputStream cos = new CompressorStreamFactory().createCompressorOutputStream(compressorName, this.out);
+            ) {
+                while (( len = is.read(buffer)) > 0) {
+                    cos.write(buffer, 0, len);
+                }
+            }
+            exportFile.delete();
+            exportFile = null;
+        }
+
+        if (exportFile != null) {
+            try (InputStream is = new FileInputStream(exportFile)) {
+                while (( len = is.read(buffer)) > 0) {
+                    this.out.write(buffer, 0, len);
+                }
+            }
+            exportFile.delete();
+        }
+    }
+
+
+
+    /**
+     * Builder class that makes a SQLExporter.
+     *
+     */
+    public static class Builder{
+        private final OutputStream out;
+        private final String extension;
+        private final StringConverter stringConverter;
+        private final File tmpdir;
+        private final List<EntryConfig> files = new ArrayList<>();
+
+        public Builder(OutputStream out, String extension, StringConverter stringConverter){
+            Objects.requireNonNull(out);
+            Objects.requireNonNull(extension);
+            this.out = out;
+            this.extension = extension;
+            this.stringConverter = stringConverter != null ? stringConverter : new DefaultStringConverter();
+            File tmpdir;
+            try {
+                tmpdir = Files.createTempDirectory("export-").toFile();
+            } catch (Exception ex) {
+                tmpdir = null;
+            }
+            this.tmpdir = tmpdir;
+        }
+
+        public Builder(OutputStream out, String extension, String stringConverterClassName){
+            Objects.requireNonNull(out);
+            Objects.requireNonNull(extension);
+            this.out = out;
+            this.extension = extension;
+            StringConverter stringConverter;
+            try {
+                stringConverter = (StringConverter) Class.forName(stringConverterClassName).getDeclaredConstructor().newInstance();
+            } catch (Exception ex) {
+                stringConverter = new DefaultStringConverter();
+            }
+            this.stringConverter = stringConverter;
+            File tmpdir;
+            try {
+                tmpdir = Files.createTempDirectory("export-").toFile();
+            } catch (Exception ex) {
+                tmpdir = null;
+            }
+            this.tmpdir = tmpdir;
+        }
+
+        public Builder addFile(Map<String, Object> m){
+            Objects.requireNonNull(m);
+            addFile(new EntryConfig(m));
+            return this;
+        }
+
+        public Builder addFile(EntryConfig file){
+            Objects.requireNonNull(file);
+            files.add(file);
+            return this;
+        }
+
+        public SQLExporter build(){
+            return new SQLExporter(this);
+        }
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporterFactory.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporterFactory.java
@@ -1,0 +1,72 @@
+package gsrs.module.substance.exporters;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import ix.ginas.exporters.ExporterFactory;
+import ix.ginas.exporters.OutputFormat;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Created by Egor Puzanov.
+ */
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SQLExporterFactory implements ExporterFactory {
+
+    private OutputFormat format = new OutputFormat("custom.xlsx", "Custom Report (xlsx) File");
+    private String stringConverter = null;
+    private List<Map<String, Object>> files;
+
+    public void setFormat(Map<String, String> m) {
+        this.format = new OutputFormat(m.get("extension"), m.get("displayName"));
+    }
+
+    public void setStringConverter(String stringConverter) {
+        this.stringConverter = stringConverter;
+    }
+
+    public void setFiles(Map<Integer, Map<String, Object>> m) {
+        this.files = (List<Map<String, Object>>) m.entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(e->e.getValue())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean supports(Parameters params) {
+        return params.getFormat().equals(format);
+    }
+
+    @Override
+    public Set<OutputFormat> getSupportedFormats() {
+        return Collections.singleton(format);
+    }
+
+    @Override
+    public SQLExporter createNewExporter(OutputStream out, Parameters params) throws IOException {
+        SQLExporter.Builder builder = new SQLExporter.Builder(out, format.getExtension(), stringConverter);
+        for (Map<String, Object> file : files) {
+            builder = builder.addFile(file);
+        }
+        return builder.build();
+    }
+
+    @Override
+    public JsonNode getSchema() {
+        ObjectNode parameters = JsonNodeFactory.instance.objectNode();
+        return parameters;
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporterFactory.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/exporters/SQLExporterFactory.java
@@ -7,12 +7,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import ix.ginas.exporters.ExporterFactory;
 import ix.ginas.exporters.OutputFormat;
+import ix.ginas.models.v1.Substance;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -23,7 +22,7 @@ import java.util.stream.Collectors;
  */
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SQLExporterFactory implements ExporterFactory {
+public class SQLExporterFactory implements ExporterFactory<Substance> {
 
     private OutputFormat format = new OutputFormat("custom.xlsx", "Custom Report (xlsx) File");
     private String stringConverter = null;

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/ScheduledExportTask.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/ScheduledExportTask.java
@@ -116,6 +116,32 @@ public class ScheduledExportTask extends ScheduledTaskInitializer {
     private List<DestinationConfig> destinations = new ArrayList<DestinationConfig>();
     private String extension;
     private String filenameTemplate = "auto-export-$DATE$";
+    private Map<String, String> parameters = new HashMap<>();
+    private boolean preserveExports = false;
+    private boolean publicOnly = false;
+    private String query = null;
+    private String username;
+    @JsonIgnore
+    private final Pattern PERIOD_PAT = Pattern.compile(":\\[(P[0-9YMWD]*)");
+
+    @Autowired
+    private SubstanceRepository substanceRepository;
+
+    @Autowired
+    private ExportService exportService;
+
+    @Autowired
+    private GsrsExportConfiguration gsrsExportConfiguration;
+
+    @Autowired
+    private SubstanceEntityService substanceEntityService;
+
+    @Autowired
+    private SubstanceLegacySearchService searchService;
+
+    @Autowired
+    protected PlatformTransactionManager transactionManager;
+
 
     public void setDescription(String description) {
         this.description = description;
@@ -176,33 +202,6 @@ public class ScheduledExportTask extends ScheduledTaskInitializer {
     public void setUsername(String username) {
         this.username = username;
     }
-
-    private Map<String, String> parameters = new HashMap<>();
-    private boolean preserveExports = false;
-    private boolean publicOnly = false;
-    private String query = null;
-    private String username;
-
-    @JsonIgnore
-    private final Pattern PERIOD_PAT = Pattern.compile(":\\[(P[0-9YMWD]*)");
-
-    @Autowired
-    private SubstanceRepository substanceRepository;
-
-    @Autowired
-    private ExportService exportService;
-
-    @Autowired
-    private GsrsExportConfiguration gsrsExportConfiguration;
-
-    @Autowired
-    private SubstanceEntityService substanceEntityService;
-
-    @Autowired
-    private SubstanceLegacySearchService searchService;
-
-    @Autowired
-    protected PlatformTransactionManager transactionManager;
 
     protected static class SmtpFileSystemConfigBuilder extends FileSystemConfigBuilder {
 

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/ScheduledExportTask.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/ScheduledExportTask.java
@@ -1,0 +1,765 @@
+package gsrs.module.substance.tasks;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import gov.nih.ncats.common.util.TimeUtil;
+import gov.nih.ncats.common.util.Unchecked;
+
+import gsrs.autoconfigure.GsrsExportConfiguration;
+import gsrs.module.substance.SubstanceEntityService;
+import gsrs.module.substance.controllers.SubstanceLegacySearchService;
+import gsrs.module.substance.repository.SubstanceRepository;
+import gsrs.scheduledTasks.ScheduledTaskInitializer;
+import gsrs.scheduledTasks.SchedulerPlugin;
+import gsrs.service.ExportService;
+
+import ix.core.models.Principal;
+import ix.core.search.SearchRequest;
+import ix.core.search.SearchResult;
+import ix.ginas.exporters.*;
+import ix.ginas.models.v1.Substance;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jakarta.mail.Authenticator;
+import jakarta.mail.Message;
+import jakarta.mail.Multipart;
+import jakarta.mail.PasswordAuthentication;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.vfs2.Capability;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSelector;
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemConfigBuilder;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.UserAuthenticationData;
+import org.apache.commons.vfs2.UserAuthenticator;
+import org.apache.commons.vfs2.auth.StaticUserAuthenticator;
+import org.apache.commons.vfs2.impl.DefaultFileSystemConfigBuilder;
+import org.apache.commons.vfs2.impl.StandardFileSystemManager;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.apache.commons.vfs2.provider.AbstractFileObject;
+import org.apache.commons.vfs2.provider.AbstractFileSystem;
+import org.apache.commons.vfs2.provider.AbstractOriginatingFileProvider;
+import org.apache.commons.vfs2.provider.GenericFileName;
+import org.apache.commons.vfs2.provider.url.UrlFileNameParser;
+import org.apache.commons.vfs2.util.DelegatingFileSystemOptionsBuilder;
+import org.apache.commons.vfs2.util.FileObjectUtils;
+import org.apache.commons.vfs2.util.UserAuthenticatorUtils;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Entities;
+import org.jsoup.safety.Safelist;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Used to schedule and upload Reports
+ *
+ * @author Egor Puzanov
+ *
+ */
+
+@Slf4j
+@Data
+public class ScheduledExportTask extends ScheduledTaskInitializer {
+
+    private String description;
+    private List<DestinationConfig> destinations = new ArrayList<DestinationConfig>();
+    private String extension;
+    private String filenameTemplate = "auto-export-$DATE$";
+    private Map<String, String> parameters = new HashMap<>();
+    private boolean preserveExports = false;
+    private boolean publicOnly = false;
+    private String query = null;
+    private String username;
+
+    @JsonIgnore
+    private final Pattern PERIOD_PAT = Pattern.compile(":\\[(P[0-9YMWD]*)");
+
+    @Autowired
+    private SubstanceRepository substanceRepository;
+
+    @Autowired
+    private ExportService exportService;
+
+    @Autowired
+    private GsrsExportConfiguration gsrsExportConfiguration;
+
+    @Autowired
+    private SubstanceEntityService substanceEntityService;
+
+    @Autowired
+    private SubstanceLegacySearchService searchService;
+
+    @Autowired
+    protected PlatformTransactionManager transactionManager;
+
+    protected static class SmtpFileSystemConfigBuilder extends FileSystemConfigBuilder {
+
+        private static final SmtpFileSystemConfigBuilder INSTANCE = new SmtpFileSystemConfigBuilder();
+
+        private static final String TO = "TO";
+        private static final String FROM = "FROM";
+        private static final String SUBJECT = "SUBJECT";
+        private static final String BODY = "BODY";
+        private static final String FOOTER = "FOOTER";
+        private static final String RECORDTEMPLATE = "RECORDTEMPLATE";
+        private static final String CHARSET = "CHARSET";
+        private static final String STARTTLS = "STARTTLS";
+        private static final String MAXSIZE = "MAXSIZE";
+
+        public static SmtpFileSystemConfigBuilder getInstance() {
+            return INSTANCE;
+        }
+
+        private SmtpFileSystemConfigBuilder() {
+            super("smtp.");
+        }
+
+        public void setTo(final FileSystemOptions options, final String to) {
+            this.setParam(options, TO, to);
+        }
+        public void setFrom(final FileSystemOptions options, final String from) {
+            this.setParam(options, FROM, from);
+        }
+        public void setSubject(final FileSystemOptions options, final String subject) {
+            this.setParam(options, SUBJECT, subject);
+        }
+        public void setBody(final FileSystemOptions options, final String body) {
+            this.setParam(options, BODY, body);
+        }
+        public void setFooter(final FileSystemOptions options, final String footer) {
+            this.setParam(options, FOOTER, footer);
+        }
+        public void setRecordTemplate(final FileSystemOptions options, final String template) {
+            this.setParam(options, RECORDTEMPLATE, template);
+        }
+        public void setStartTls(final FileSystemOptions options, final String starttls) {
+            this.setParam(options, STARTTLS, starttls);
+        }
+        public void setCharset(final FileSystemOptions options, final String charset) {
+            this.setParam(options, CHARSET, charset);
+        }
+        public void setMaxSize(final FileSystemOptions options, final String maxSize) {
+            this.setParam(options, MAXSIZE, maxSize);
+        }
+
+        public String getTo(final FileSystemOptions options) {
+            return this.getString(options, TO);
+        }
+        public String getFrom(final FileSystemOptions options) {
+            return this.getString(options, FROM);
+        }
+        public String getSubject(final FileSystemOptions options) {
+            return this.getString(options, SUBJECT);
+        }
+        public String getBody(final FileSystemOptions options) {
+            return this.getString(options, BODY);
+        }
+        public String getFooter(final FileSystemOptions options) {
+            return this.getString(options, FOOTER, "");
+        }
+        public String getRecordTemplate(final FileSystemOptions options) {
+            return this.getString(options, RECORDTEMPLATE);
+        }
+        public String getCharset(final FileSystemOptions options) {
+            return this.getString(options, CHARSET, "utf-8");
+        }
+        public String getStartTls(final FileSystemOptions options) {
+            return this.getString(options, STARTTLS, "true");
+        }
+        public int getMaxSize(final FileSystemOptions options) {
+            String ms = this.getString(options, MAXSIZE, String.valueOf(Integer.MAX_VALUE));
+            try {
+                switch (ms.substring(ms.length() - 2).toUpperCase()) {
+                    case "KB": return Float.valueOf(Float.valueOf(ms.substring(0, ms.length() - 2)) * 1024).intValue();
+                    case "MB": return Float.valueOf(Float.valueOf(ms.substring(0, ms.length() - 2)) * 1024 * 1024).intValue();
+                    case "GB": return Float.valueOf(Float.valueOf(ms.substring(0, ms.length() - 2)) * 1024 * 1024 * 1024).intValue();
+                    default: return Float.valueOf(ms).intValue();
+                }
+            } catch (final Exception e) {}
+            return Integer.MAX_VALUE;
+        }
+
+        protected SmtpFileSystemConfigBuilder(final String prefix) {
+            super(prefix);
+        }
+
+        @Override
+        protected Class<? extends FileSystem> getConfigClass() {
+            return SmtpFileSystem.class;
+        }
+    }
+
+
+    protected static class SmtpFileProvider extends AbstractOriginatingFileProvider {
+
+        private static final SmtpFileProvider INSTANCE = new SmtpFileProvider();
+
+        public SmtpFileProvider() {
+            setFileNameParser(new UrlFileNameParser());
+        }
+
+        public static SmtpFileProvider getInstance() {
+            return INSTANCE;
+        }
+
+        static final UserAuthenticationData.Type[] AUTHENTICATOR_TYPES =
+            {
+                UserAuthenticationData.USERNAME,
+                UserAuthenticationData.PASSWORD
+            };
+
+        static final Collection<Capability> CAPABILITIES =
+            Collections.unmodifiableCollection(
+                Arrays.asList(
+                    Capability.CREATE,
+                    Capability.URI,
+                    Capability.WRITE_CONTENT
+                    )
+            );
+
+        private Session createSession(final GenericFileName rootName,
+                final FileSystemOptions fileSystemOptions) throws FileSystemException {
+            UserAuthenticationData authData = null;
+            SmtpFileSystemConfigBuilder builder = (SmtpFileSystemConfigBuilder) getConfigBuilder();
+            try {
+                Properties props = new Properties();
+                props.put("mail.smtp.starttls.enable", builder.getStartTls(fileSystemOptions));
+                props.put("mail.smtp.host", rootName.getHostName());
+                props.put("mail.smtp.port", rootName.getPort());
+                authData = UserAuthenticatorUtils.authenticate(fileSystemOptions, AUTHENTICATOR_TYPES);
+                final String username = authData == null
+                    ? rootName.getUserName()
+                    : String.valueOf(UserAuthenticatorUtils.getData(
+                        authData,
+                        UserAuthenticationData.USERNAME,
+                        UserAuthenticatorUtils.toChar(rootName.getUserName())));
+                final String password = authData == null
+                    ? rootName.getPassword()
+                    : String.valueOf(UserAuthenticatorUtils.getData(
+                        authData,
+                        UserAuthenticationData.PASSWORD,
+                        UserAuthenticatorUtils.toChar(rootName.getPassword())));
+                if (username == null) {
+                    return Session.getInstance(props);
+                } else {
+                    props.put("mail.smtp.auth", "true");
+                    return Session.getInstance(props,
+                        new Authenticator() {
+                            @Override
+                            protected PasswordAuthentication getPasswordAuthentication() {
+                                return new PasswordAuthentication(username, password);
+                            }
+                        });
+                }
+            } catch (final Exception e) {
+                throw new FileSystemException("vfs.provider/copy-file.error", rootName, e);
+            } finally {
+                UserAuthenticatorUtils.cleanup(authData);
+            }
+        }
+
+        @Override
+        protected FileSystem doCreateFileSystem(final FileName name, final FileSystemOptions fileSystemOptions)
+                throws FileSystemException {
+            SmtpFileSystemConfigBuilder builder = (SmtpFileSystemConfigBuilder) getConfigBuilder();
+            try {
+                Session session = createSession((GenericFileName) name, fileSystemOptions);
+                MimeMessage message = new MimeMessage(session);
+                message.setFrom(new InternetAddress(builder.getFrom(fileSystemOptions)));
+                message.setRecipients(Message.RecipientType.TO,
+                    InternetAddress.parse(builder.getTo(fileSystemOptions)));
+                String charset = builder.getCharset(fileSystemOptions);
+                message.setSubject(builder.getSubject(fileSystemOptions), charset);
+                return new SmtpFileSystem(name,
+                    null,
+                    fileSystemOptions,
+                    message,
+                    builder.getBody(fileSystemOptions),
+                    builder.getFooter(fileSystemOptions),
+                    builder.getRecordTemplate(fileSystemOptions),
+                    charset,
+                    builder.getMaxSize(fileSystemOptions));
+            } catch (final Exception e) {
+                e.printStackTrace();
+                throw new FileSystemException("vfs.provider/copy-file.error", name, e);
+            }
+        }
+
+        @Override
+        public Collection<Capability> getCapabilities() {
+            return CAPABILITIES;
+        }
+
+        @Override
+        public FileSystemConfigBuilder getConfigBuilder() {
+            return SmtpFileSystemConfigBuilder.getInstance();
+        }
+    }
+
+    protected static class SmtpFileSystem extends AbstractFileSystem {
+
+        private Message message;
+        private int maxSize;
+        private String body;
+        private String footer;
+        private String recordTemplate;
+        private String charset;
+
+        public SmtpFileSystem (final FileName name,
+                final FileObject object,
+                final FileSystemOptions fileSystemOptions,
+                final Message message,
+                final String body,
+                final String footer,
+                final String recordTemplate,
+                final String charset,
+                final int maxSize) {
+            super(name, object, fileSystemOptions);
+            this.message = message;
+            this.body = body;
+            this.footer = footer;
+            this.recordTemplate = recordTemplate;
+            this.charset = charset;
+            this.maxSize = maxSize;
+        }
+
+        @Override
+        protected void addCapabilities(final Collection<Capability> caps) {
+            caps.addAll(SmtpFileProvider.CAPABILITIES);
+        }
+
+        @Override
+        protected FileObject createFile(final AbstractFileName name) throws FileSystemException {
+            return new SmtpFileObject(name, this);
+        }
+
+        @Override
+        public Object getAttribute(final String attrName) throws FileSystemException {
+            switch (attrName) {
+                case "content": try {return message.getContent();} catch (final Exception e) {}; return null;
+                case "body": return body;
+                case "footer": return footer;
+                case "recordTemplate": return recordTemplate;
+                case "charset": return charset;
+                default: return null;
+            }
+        }
+
+        @Override
+        public void setAttribute(final String attrName, final Object value) throws FileSystemException {
+            int messageSize = Integer.MAX_VALUE;
+            if ("content".equals(attrName)) {
+                String contentType = "text/plain";
+                if (Multipart.class.isInstance(value)) {
+                    contentType = ((Multipart) value).getContentType();
+                }
+                try {
+                    message.setContent(value, contentType);
+                    message.saveChanges();
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    message.writeTo(out);
+                    messageSize = new String(out.toByteArray(), StandardCharsets.UTF_8).getBytes(StandardCharsets.UTF_8).length;
+                } catch (final Exception e) {
+                    e.printStackTrace();
+                    throw new FileSystemException("vfs.provider/set-attribute.error", e, attrName, this);
+                }
+                if (messageSize > maxSize) {
+                    throw new FileSystemException("vfs.provider/set-attribute.error",
+                        new Exception("No space left. The maximum message size limit is exceeded."),
+                        attrName, this);
+                }
+            }
+        }
+
+        @Override
+        protected void doCloseCommunicationLink() {
+            if (message != null) {
+                try {
+                    message.getSession().getTransport("smtp").connect();
+                    Transport.send(message);
+                    //ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    //message.writeTo(out);
+                    //System.out.println(new String(out.toByteArray(), StandardCharsets.UTF_8));
+                } catch (final Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    message = null;
+                }
+            }
+        }
+    }
+
+    protected static class SmtpFileObject extends AbstractFileObject<SmtpFileSystem> {
+
+        protected SmtpFileObject(final AbstractFileName fileName,
+            final SmtpFileSystem fileSystem) {
+            super(fileName, fileSystem);
+        }
+
+        @Override
+        protected String[] doListChildren() throws Exception {
+            throw new FileSystemException("Not implemented.");
+        }
+
+        @Override
+        protected FileType doGetType() throws Exception {
+            if (this.getName().getBaseName().contains(".")) {
+                return FileType.FILE;
+            } else {
+                return FileType.FOLDER;
+            }
+        }
+
+        @Override
+        protected long doGetContentSize() throws Exception {
+            throw new FileSystemException("Not implemented.");
+        }
+
+        @Override
+        public FileObject getParent() throws FileSystemException {
+            return this;
+        }
+
+        private static String cleanToText(String content, String charset) {
+            Document.OutputSettings settings = new Document.OutputSettings();
+            settings.prettyPrint(false);
+            settings.charset(charset);
+            settings.escapeMode(Entities.EscapeMode.base);
+            String safeText = Jsoup.clean(content, "", Safelist.none(), settings);
+            return(safeText);
+        }
+
+        @Override
+        public void copyFrom(final FileObject file, final FileSelector selector) throws FileSystemException {
+            if (!FileObjectUtils.exists(file)) {
+                throw new FileSystemException("vfs.provider/copy-missing-file.error", file);
+            }
+            final ArrayList<FileObject> files = new ArrayList<>();
+            file.findFiles(selector, false, files);
+            SmtpFileSystem fileSystem = (SmtpFileSystem) getFileSystem();
+            String body = (String) fileSystem.getAttribute("body");
+            String recordTemplate = body == null ? null : (String) fileSystem.getAttribute("recordTemplate");
+            String footer = (String) fileSystem.getAttribute("footer");
+            String charset = (String) fileSystem.getAttribute("charset");
+            List<Integer> subst_columns = new ArrayList<Integer>();
+            if (recordTemplate != null) {
+                Matcher m = Pattern.compile("\\{([0-9]+)\\}").matcher(recordTemplate);
+                StringBuffer sb = new StringBuffer();
+                while (m.find()) {
+                    subst_columns.add(Integer.parseInt(m.group(1)));
+                    m.appendReplacement(sb, "%s");
+                }
+                m.appendTail(sb);
+                if (!subst_columns.isEmpty()) {
+                    recordTemplate = sb.toString();
+                }
+            }
+            try {
+                CSVFormat format = CSVFormat.Builder
+                    .create(CSVFormat.RFC4180)
+                    .setHeader()
+                    .setSkipHeaderRecord(true)
+                    .build();
+                MimeMultipart multipart = new MimeMultipart();
+                MimeBodyPart messageBodyPart;
+                String mimetype;
+                for (final FileObject srcFile : files) {
+                    try {
+                        if (srcFile.getType().hasContent()) {
+                            messageBodyPart = new MimeBodyPart();
+                            mimetype = Files.probeContentType(srcFile.getPath());
+                            messageBodyPart.attachFile(srcFile.getName().getPath(), mimetype + "; charset=" + charset, "base64");
+                            messageBodyPart.setFileName(this.getName().getBaseName());
+                            multipart.addBodyPart(messageBodyPart);
+                            if (recordTemplate != null) {
+                                if ("text/csv".equals(mimetype)) {
+                                    CSVParser parser = CSVParser.parse(
+                                        new InputStreamReader(srcFile.getContent().getInputStream()),
+                                        format);
+                                    for (CSVRecord csvRecord : parser) {
+                                        if (subst_columns.isEmpty()) {
+                                            subst_columns = IntStream.range(0, csvRecord.size()).boxed().collect(Collectors.toList());
+                                        }
+                                        List<Object> values = new ArrayList<Object>();
+                                        for (Integer idx : subst_columns) {
+                                            values.add(csvRecord.get(idx.intValue()));
+                                        }
+                                        body = body + "\n" + String.format(recordTemplate, values.stream().toArray(Object[]::new));
+                                    }
+                                    multipart.removeBodyPart(messageBodyPart);
+                                }
+                            }
+                        }
+                    } catch (final IOException e) {
+                        throw new FileSystemException("vfs.provider/copy-file.error", e, srcFile, this);
+                    }
+                }
+                body = body + "\n" + footer;
+                messageBodyPart = new MimeBodyPart();
+                messageBodyPart.setText(cleanToText(body, charset), charset);
+                messageBodyPart.setHeader("Content-Transfer-Encoding", "base64");
+                if (!body.equals(String.valueOf(messageBodyPart.getContent()))) {
+                    MimeMultipart alt = new MimeMultipart("alternative", messageBodyPart);
+                    messageBodyPart = new MimeBodyPart();
+                    messageBodyPart.setText(body, charset, "html");
+                    messageBodyPart.setHeader("Content-Transfer-Encoding", "base64");
+                    alt.addBodyPart(messageBodyPart);
+                    messageBodyPart = new MimeBodyPart();
+                    messageBodyPart.setContent(alt);
+                }
+                multipart.addBodyPart(messageBodyPart, 0);
+                fileSystem.setAttribute("content", multipart);
+            } catch (final Exception e) {
+                throw new FileSystemException("vfs.provider/copy-file.error", e, file, this);
+            }
+        }
+    }
+
+    @Data
+    private class DestinationConfig {
+        private final URI uri;
+        private final FileSystemOptions options;
+
+        public DestinationConfig(Map<String, String> dst) throws FileSystemException, URISyntaxException {
+            FileSystemOptions opts = new FileSystemOptions();
+            this.uri = new URI(dst.remove("uri"));
+            String scheme = this.uri.getScheme().toLowerCase();
+            String domain =  dst.remove("domain");
+            String user =  dst.remove("user");
+            String password = dst.remove("password");
+            if (user != null && user.length() > 0 && password != null && password.length() > 0) {
+                UserAuthenticator auth = new StaticUserAuthenticator(domain, user, password);
+                DefaultFileSystemConfigBuilder.getInstance().setUserAuthenticator(opts, auth);
+            }
+            if (dst.size() > 0) {
+                StandardFileSystemManager manager = new StandardFileSystemManager();
+                manager.addProvider("smtp", SmtpFileProvider.getInstance());
+                manager.init();
+                DelegatingFileSystemOptionsBuilder delegate = new DelegatingFileSystemOptionsBuilder(manager);
+                for (Map.Entry<String, String> entry : dst.entrySet()) {
+                    try {
+                        delegate.setConfigString(opts, scheme, entry.getKey(), entry.getValue());
+                    } catch (Exception e) {
+                        log.error("The delegating configuration builder cant set value \"" + entry.getValue() + "\" for the key \"" + entry.getKey() + "\" of the scheme \"" + scheme + "\".");
+                    }
+                }
+                manager.close();
+            }
+            log.debug(opts.toString());
+            this.options = opts;
+        }
+
+        public FileObject getFileObject(FileSystemManager manager) throws FileSystemException {
+            return manager.resolveFile(uri.toString(), options);
+        }
+    }
+
+    @JsonProperty(value="destinations")
+    public void setDestinations(Map<String, Map<String, String>> m) throws FileSystemException, NoSuchMethodException, URISyntaxException {
+        for (Map<String, String> value : m.values()) {
+            destinations.add(new DestinationConfig(value));
+        }
+    }
+
+    @Override
+    public void run(SchedulerPlugin.JobStats stats, SchedulerPlugin.TaskListener l) {
+        log.debug("About to call runAsAdmin with transaction");
+        TransactionTemplate transactionRunReport = new TransactionTemplate(transactionManager);
+        transactionRunReport.setReadOnly(true);
+        transactionRunReport.executeWithoutResult((s)->{
+            Optional<ExportDir.ExportFile<ExportMetaData>> ofile = handleExport(l);
+            if (ofile.isPresent()) {
+                ExportDir.ExportFile<ExportMetaData> file = ofile.get();
+                uploadFile(file, l);
+                if (!preserveExports) {
+                    file.delete();
+                }
+            }
+            log.debug("completed handleRun");
+        });
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    private Function<String, String> fileNameGenerator() {
+        return date -> filenameTemplate.replace("$DATE$", date);
+    }
+
+    private Optional<ExportDir.ExportFile<ExportMetaData>> handleExport(SchedulerPlugin.TaskListener l) {
+        log.debug("Running export");
+        try {
+            Principal user = new Principal(username, null);
+            ExportMetaData emd = new ExportMetaData("export-all-gsrs", null, user.username, publicOnly, extension)
+                .onTotalChanged((c) -> {
+                    l.message("Exported " + c + " records");
+                });
+            Stream<Substance> substanceStream = getStreamSupplier();
+            Stream<Substance> effectivelyFinalStream = filterStream(substanceStream, publicOnly, parameters);
+            ExportProcess<Substance> p = exportService.createExport(emd,() -> effectivelyFinalStream);
+            log.trace("p: " + (p==null ? "null" : "not null"));
+            log.trace("publicOnly: " + publicOnly);
+            l.message("Run export for " + extension + " extension.");
+            p.run(r->r.run(), out -> Unchecked.uncheck(() -> getExporterFor(extension, out, publicOnly, parameters)));
+            return exportService.getFile(user.username, emd.getFilename());
+        } catch (Exception e) {
+            log.error("Error in ScheduledExportTask: " + e.getMessage());
+            e.printStackTrace();
+        }
+        return Optional.empty();
+    }
+
+    private void uploadFile(ExportDir.ExportFile<ExportMetaData> file, SchedulerPlugin.TaskListener l) {
+        l.message("Uploading file " + file.getFile().getName());
+        StandardFileSystemManager manager = new StandardFileSystemManager();
+        OutputStream outputStream = null;
+        LocalDate ld = TimeUtil.getCurrentLocalDate();
+        String date = ld.format(DateTimeFormatter.ISO_LOCAL_DATE);
+        String fname = fileNameGenerator().apply(date) + "." + extension;
+
+        try {
+            manager.addProvider("smtp", SmtpFileProvider.getInstance());
+            manager.init();
+            String filename = file.getFile().getAbsolutePath();
+            FileObject lfo = manager.resolveFile(filename);
+            if (lfo.exists()) {
+                for (DestinationConfig dst : destinations) {
+                    l.message("Uploading file to " + dst.getUri().toString());
+                    log.debug("Destination URI: " + dst.getUri().toString());
+                    log.trace("Options: " + dst.getOptions().toString());
+                    FileObject rfo = dst.getFileObject(manager);
+                    if (!rfo.getParent().exists()) {
+                        rfo.getParent().createFolder();
+                    }
+                    if (rfo.isFolder()) {
+                        rfo = rfo.resolveFile(fname);
+                    }
+                    rfo.copyFrom(lfo, Selectors.SELECT_SELF);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Exception", e);
+            e.printStackTrace();
+        } finally {
+            manager.close();
+        }
+    }
+
+    private Exporter<Substance> getExporterFor(String extension, OutputStream pos, boolean publicOnly, Map<String, String> parameters)
+            throws IOException {
+
+        log.trace("getExporterFor, extension: " + extension + "; pos: " + pos + "parameters: " + parameters);
+        ExporterFactory.Parameters params = createParamters(extension, publicOnly, parameters);
+        log.trace("create params");
+
+        log.trace("gsrsExportConfiguration: " + (gsrsExportConfiguration==null ? "null" : "not null"));
+        ExporterFactory<Substance> factory = gsrsExportConfiguration.getExporterFor(substanceEntityService.getContext(), params);
+
+        log.trace("factory: " + factory);
+        if (factory == null) {
+            // TODO handle null couldn't find factory for params
+            throw new IllegalArgumentException("could not find suitable factory for " + params);
+        }
+        return factory.createNewExporter(pos, params);
+    }
+
+    protected ExporterFactory.Parameters createParamters(String extension, boolean publicOnly, Map<String, String> parameters) {
+        for (OutputFormat f : gsrsExportConfiguration.getAllSupportedFormats(substanceEntityService.getContext())) {
+            if (extension.equals(f.getExtension())) {
+                return new DefaultParameters(f, publicOnly);
+            }
+        }
+        throw new IllegalArgumentException("could not find supported exporter for extension '" + extension + "'");
+
+    }
+
+    private Stream<Substance> getStreamSupplier() throws UnsupportedEncodingException {
+        if (query != null && !query.isEmpty()) {
+            Matcher m = PERIOD_PAT.matcher(query);
+            StringBuffer sb = new StringBuffer();
+            while (m.find()) {
+                m.appendReplacement(sb, ":[" + String.valueOf(Period.parse(m.group(1)).subtractFrom(ZonedDateTime.now()).getLong(ChronoField.INSTANT_SECONDS)) + "000");
+            }
+            m.appendTail(sb);
+            SearchRequest sr = new SearchRequest.Builder()
+                .kind(Substance.class)
+                .fdim(0)
+                .query(sb.toString())
+                .top(Integer.MAX_VALUE)
+                .build();
+            return new TransactionTemplate(transactionManager).execute(ts -> {
+                try {
+                    SearchResult result = searchService.search(sr.getQuery(), sr.getOptions());
+                    result.waitForFinish();
+                    return result.getMatches().stream();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    throw new RuntimeException(e);
+                }
+            });
+        } else {
+            return substanceRepository.streamAll();
+        }
+    }
+
+    protected Stream<Substance> filterStream(Stream<Substance> stream, boolean publicOnly, Map<String, String> parameters) {
+        if (publicOnly) {
+            return stream.filter(s -> s.getAccess().isEmpty());
+        }
+        return stream;
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/ScheduledExportTask.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/ScheduledExportTask.java
@@ -110,13 +110,73 @@ import org.springframework.transaction.support.TransactionTemplate;
  */
 
 @Slf4j
-@Data
 public class ScheduledExportTask extends ScheduledTaskInitializer {
 
     private String description;
     private List<DestinationConfig> destinations = new ArrayList<DestinationConfig>();
     private String extension;
     private String filenameTemplate = "auto-export-$DATE$";
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public void setExtension(String extension) {
+        this.extension = extension;
+    }
+
+    public String getFilenameTemplate() {
+        return filenameTemplate;
+    }
+
+    public void setFilenameTemplate(String filenameTemplate) {
+        this.filenameTemplate = filenameTemplate;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters = parameters;
+    }
+
+    public boolean isPreserveExports() {
+        return preserveExports;
+    }
+
+    public void setPreserveExports(boolean preserveExports) {
+        this.preserveExports = preserveExports;
+    }
+
+    public boolean isPublicOnly() {
+        return publicOnly;
+    }
+
+    public void setPublicOnly(boolean publicOnly) {
+        this.publicOnly = publicOnly;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
     private Map<String, String> parameters = new HashMap<>();
     private boolean preserveExports = false;
     private boolean publicOnly = false;
@@ -703,7 +763,7 @@ public class ScheduledExportTask extends ScheduledTaskInitializer {
             throws IOException {
 
         log.trace("getExporterFor, extension: " + extension + "; pos: " + pos + "parameters: " + parameters);
-        ExporterFactory.Parameters params = createParamters(extension, publicOnly, parameters);
+        ExporterFactory.Parameters params = createParameters(extension, publicOnly, parameters);
         log.trace("create params");
 
         log.trace("gsrsExportConfiguration: " + (gsrsExportConfiguration==null ? "null" : "not null"));
@@ -717,7 +777,7 @@ public class ScheduledExportTask extends ScheduledTaskInitializer {
         return factory.createNewExporter(pos, params);
     }
 
-    protected ExporterFactory.Parameters createParamters(String extension, boolean publicOnly, Map<String, String> parameters) {
+    protected ExporterFactory.Parameters createParameters(String extension, boolean publicOnly, Map<String, String> parameters) {
         for (OutputFormat f : gsrsExportConfiguration.getAllSupportedFormats(substanceEntityService.getContext())) {
             if (extension.equals(f.getExtension())) {
                 return new DefaultParameters(f, publicOnly);

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/ScheduledExportTask.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/tasks/ScheduledExportTask.java
@@ -686,6 +686,7 @@ public class ScheduledExportTask extends ScheduledTaskInitializer {
                     file.delete();
                 }
             }
+            l.complete();
             log.debug("completed handleRun");
         });
     }


### PR DESCRIPTION
This PR add two extensions:

### gsrs.module.substance.exporters.SQLExporterFactory
The SQLExporter can be used for the exporting the substances information using SQL queries to the GSRS database. The results can be exportet as XLSX or CSV files compressed if needed.

#### Dependencies
* org.apache.commons.compress
* org.apache.commons.csv
* org.apache.poi

#### Configuration

```
ix.ginas.export.exporterfactories.substances.list.SQLExporterFactory1 = {
    "exporterFactoryClass": "gsrs.module.substance.exporters.SQLExporterFactory",
    "parameters": {
        "format": {
            "extension": "dnames.xlsx",
            "displayName": "Display Names (xlsx) File"
        },
        files: [
            {
                "name":"Names",
                "format":"PostgreSQLCsv",
                "header":"UNII,NAME",
                "sql":"SELECT S.APPROVAL_ID AS UNII, COALESCE(N.FULL_NAME, N.NAME) AS NAME FROM IX_GINAS_SUBSTANCES S LEFT JOIN IX_GINAS_NAME N ON S.UUID = N.OWNER_UUID AND N.DISPLAY_NAME = '1'"
            },
            {
                "name":"CAS",
                "format":"PostgreSQLCsv",
                "header":"UNII,CAS",
                "sql":"SELECT S.APPROVAL_ID AS UNII, C.CODE AS CAS FROM IX_GINAS_SUBSTANCES S LEFT JOIN IX_GINAS_CODE C ON S.UUID = C.OWNER_UUID AND C.CODE_SYSTEM = 'CAS' AND C.TYPE = 'PRIMARY'"
            }
        ]
    }
}

ix.ginas.export.exporterfactories.substances.list.SQLExporterFactory2 = {
    "exporterFactoryClass": "gsrs.module.substance.exporters.SQLExporterFactory",
    "parameters": {
        "format": {
            "extension": "cas.zip",
            "displayName": "CAS Codes Report (zip) File"
        },
        files: [
            {
                "name":"Names.csv",
                "encoding":"ISO-8859-1",
                "delimiter":";",
                "quoteChar":"\"",
                "escapeChar":"",
                "header":"UNII;NAME",
                "sql":"""
SELECT
    S.APPROVAL_ID AS UNII,
    COALESCE(N.FULL_NAME, N.NAME) AS NAME
FROM IX_GINAS_SUBSTANCE S
LEFT JOIN IX_GINAS_NAME N ON S.UUID = N.OWNER_UUID
WHERE S.DEPRECATED = '0'
    AND N.DISPLAY_NAME = '1'
"""
            },
            {
                "name":"codes/CAS.csv",
                "encoding":"ISO-8859-1",
                "format":"Default",
                "header":"UNII,CAS",
                "sql":"""
SELECT
    S.APPROVAL_ID AS UNII,
    C.CODE AS CAS
FROM IX_GINAS_SUBSTANCE S
LEFT JOIN IX_GINAS_CODE C ON S.UUID = C.OWNER_UUID
WHERE S.DEPRECATED = '0'
    AND C.CODE_SYSTEM = 'CAS'
    AND C.TYPE = 'PRIMARY'
"""
            }
        ]
    }
}
```

### gsrs.module.substance.tasks.ScheduledExportTask
The ScheduledExportTask can be used to run any GSRS export on schedule and send it result file to any VFS2 supported destinations.
Following destinations protocols are supported: file://, ftp://, ftps://, sftp://, smtp://.
The 'query' parameter supports the Period deffinition in the ISO-8601 calendar system format.
The SMTP destinations supports mail body in HTML and PLAIN format. The report sended as the mail attachment.
The size of the Mail can be limited by maxSize paramater.
The CSV reports can be sendet within the mail body if the 'recordTemplate' parameters is provided.
The 'recordTemplate' parameter supports the '{0}' format for fields index. The '%s' supported for 'recordTemplate' formatting as well,
but it can not be combined with the field indexing approach.

#### Dependencies
* org.apache.commons.csv
* org.apache.commons.vfs2
* org.apache.commons.net
* com.jcraft.jsch
* jakarta.activation
* jakarta.mail

#### Configuration

```
gsrs.scheduled-tasks.list.ScheduledExportTask1 = {
    "scheduledTaskClass" : "gsrs.module.substance.tasks.ScheduledExportTask",
    "parameters" : {
        "cron": "0 10 1 * * ?",
        "autorun": false,
        "description": "Scheduled last month edited substances export",
        "extension": "csv",
        "query": "root_codes_codeSystem:\"^FDA UNII$\" AND root_lastEdited:[P1M TO 10E50]",
        "filenameTemplate": "auto-export-$DATE$",
        "publicOnly": false,
        "username": "ADMIN",
        "parameters": {},
        "destinations": [
            {
                "uri": "file:///home/srs/exports/export.csv"
            },
            {
                "uri":"sftp://target_server/inbox/last_month_edited.csv",
                "user":"username",
                "password":"PASSWORD",
                "userDirIsRoot":"false",
                "strictHostKeyChecking":"no",
                "sessionTimeoutMillis":"10000"
            },
            {
                "uri":"ftp://target_server_2/gsrs_exports/",
                "user":"username",
                "password":"PASSWORD",
                "userDirIsRoot":"true",
                "pasiveMode":"true"
            },
            {
                "uri": "smtp://mail.server.org:25",
                "from": "gsrs@server.org",
                "to": "some.user@server.org",
                "subject": "Substances edited last month",
                "body": "<h1>Substances</h1></br><table><tr><th>Approval ID</th><th>Display Name</th></tr>",
                "recordTemplate": "<tr><td><a href='https://gsrs.ncats.nih.gov/ginas/app/ui/substances/{0}'>{1}</a></td><td>{2}</td></tr>",
                "footer": "</table>",
                "charset": "utf-8",
                "maxSize": "10M"
            },
            {
                "uri": "smtp://mail.server.org:25/last_month_edited.csv",
                "from": "gsrs@server.org",
                "to": "some.user@server.org",
                "subject": "Substances edited last month",
                "body": "Substances edited last month",
                "maxSize": "10M"
            }
        ]
    }
}
```
