### PR TITLE
forbid changes to display name for approved/validated substances unless

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/substance/validation/NamesValidatorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/validation/NamesValidatorTest.java
@@ -63,7 +63,7 @@ public class NamesValidatorTest extends AbstractSubstanceJpaEntityTest {
         conceptAfter.status = Substance.STATUS_APPROVED;
         ValidationResponse<Substance> response = validator.validate(conceptAfter, conceptBefore);
         Assertions.assertTrue(response.getValidationMessages().stream().anyMatch(
-                v->v.getMessageType()== ValidationMessage.MESSAGE_TYPE.ERROR && v.getMessage().contains("Additional privilege is required to change display name of approved records")));
+                v->v.getMessageType()== ValidationMessage.MESSAGE_TYPE.ERROR && v.getMessage().contains("Changing Display Name is not allowed for your user role.")));
     }
 
     private ChemicalSubstance createSimpleChemicalDuplicateNames(){

--- a/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NamesValidator.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ginas/utils/validation/validators/NamesValidator.java
@@ -43,6 +43,7 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
     private String caseSearchType = "Explicit";
 
     public static final String PRIVILEGE_FOR_DISPLAY_NAME_CHANGE = "Change Display Name";
+    public static final String PRIVILEGE_FOR_DISPLAY_NAME_CHANGE_FOR_VALIDATED = "Change Display Name for Approved";
 
     // Keep consistent with NamesUtilities
     // This and other replacers should be handled later in a new NameStandardizer class similar to HTMLNameStandardizer
@@ -291,7 +292,14 @@ public class NamesValidator extends AbstractValidatorPlugin<Substance> {
             } catch (Exception e) {
                 e.printStackTrace();
             }
-            if (oldDisplayName.isPresent() && n.displayName && !oldDisplayName.get().getName().equalsIgnoreCase(n.getName())
+
+            if(oldDisplayName.isPresent() && n.displayName && !oldDisplayName.get().getName().equalsIgnoreCase(n.getName())
+                    && Substance.STATUS_APPROVED.equals(s.status) && ! privilegeService.canDo(PRIVILEGE_FOR_DISPLAY_NAME_CHANGE_FOR_VALIDATED)){
+                GinasProcessingMessage mes = GinasProcessingMessage
+                        .ERROR_MESSAGE(
+                                "Changing Display Name is not allowed for your user role.");
+                callback.addMessage(mes);
+            } else if (oldDisplayName.isPresent() && n.displayName && !oldDisplayName.get().getName().equalsIgnoreCase(n.getName())
                     && (s.changeReason == null || !s.changeReason.equalsIgnoreCase(CHANGE_REASON_DISPLAYNAME_CHANGED))) {
                 if(privilegeService.canDo(PRIVILEGE_FOR_DISPLAY_NAME_CHANGE) || !Substance.STATUS_APPROVED.equals(s.status)) {
                     GinasProcessingMessage mes = GinasProcessingMessage


### PR DESCRIPTION
the user has the "Change Display Name for Approved" privilege