### PR TITLE
WIP: When inverting a relationship, use a configured value for change reason in the other substance

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/substance/RelationshipInvertTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/RelationshipInvertTest.java
@@ -49,8 +49,8 @@ import static org.junit.Assert.*;
 public class RelationshipInvertTest extends AbstractSubstanceJpaEntityTest {
 
     private static final String PREVIOUS_CHANGE_REASON = "previous change reason";
-    private static final String INVERSE_RELATIONSHIP_CHANGE_REASON = "Inverse relationship added/updated";
-    private static final String INVERSE_RELATIONSHIP_DELETION_REASON = "Inverse relationship deleted";
+    private static final String INVERSE_RELATIONSHIP_CHANGE_REASON = "Custom configured inverse relationship updated reason";
+    private static final String INVERSE_RELATIONSHIP_DELETION_REASON = "Custom configured inverse relationship deleted reason";
 
     File invrelate1, invrelate2;
 

--- a/gsrs-module-substance-example/src/test/java/example/substance/RelationshipInvertTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/RelationshipInvertTest.java
@@ -48,6 +48,10 @@ import static org.junit.Assert.*;
 @WithMockUser(username = "admin", roles="Admin")
 public class RelationshipInvertTest extends AbstractSubstanceJpaEntityTest {
 
+    private static final String PREVIOUS_CHANGE_REASON = "previous change reason";
+    private static final String INVERSE_RELATIONSHIP_CHANGE_REASON = "Inverse relationship added/updated";
+    private static final String INVERSE_RELATIONSHIP_DELETION_REASON = "Inverse relationship deleted";
+
     File invrelate1, invrelate2;
 
     @Autowired
@@ -238,6 +242,89 @@ public class RelationshipInvertTest extends AbstractSubstanceJpaEntityTest {
         assertEquals(0, secondPassEvents.size());
 
 
+    }
+
+    @Test
+    public void creatingInverseRelationshipShouldReplaceOldChangeReasonOnRelatedSubstance(@Autowired ApplicationEvents applicationEvents) {
+        UUID uuid1 = UUID.randomUUID();
+        UUID uuid2 = UUID.randomUUID();
+
+        createNamedSubstance(uuid1, "sub1");
+        createNamedSubstance(uuid2, "sub2");
+        updateChangeReason(uuid2, PREVIOUS_CHANGE_REASON);
+
+        addRelationshipAndCreateInverse(applicationEvents, uuid1, uuid2, "foo->bar");
+
+        Substance substance2 = substanceEntityService.get(uuid2).get();
+        assertEquals("3", substance2.version);
+        assertEquals(1, substance2.relationships.size());
+        assertEquals("bar->foo", substance2.relationships.get(0).type);
+        assertEquals(uuid1.toString(), substance2.relationships.get(0).relatedSubstance.refuuid);
+        assertEquals(INVERSE_RELATIONSHIP_CHANGE_REASON, substance2.changeReason);
+    }
+
+    @Test
+    public void updatingInverseRelationshipShouldReplaceOldChangeReasonOnRelatedSubstance(@Autowired ApplicationEvents applicationEvents) {
+        UUID uuid1 = UUID.randomUUID();
+        UUID uuid2 = UUID.randomUUID();
+
+        createNamedSubstance(uuid1, "sub1");
+        createNamedSubstance(uuid2, "sub2");
+        addRelationshipAndCreateInverse(applicationEvents, uuid1, uuid2, "foo->bar");
+        updateChangeReason(uuid2, PREVIOUS_CHANGE_REASON);
+
+        updateSourceRelationshipAndUpdateInverse(applicationEvents, uuid1, r -> r.type = "foo->bat");
+
+        Substance substance2 = substanceEntityService.get(uuid2).get();
+        assertEquals("bat->foo", substance2.relationships.get(0).type);
+        assertEquals(uuid1.toString(), substance2.relationships.get(0).relatedSubstance.refuuid);
+        assertEquals(INVERSE_RELATIONSHIP_CHANGE_REASON, substance2.changeReason);
+    }
+
+    @Test
+    public void removingInverseRelationshipShouldReplaceOldChangeReasonOnRelatedSubstance(@Autowired ApplicationEvents applicationEvents) {
+        UUID uuid1 = UUID.randomUUID();
+        UUID uuid2 = UUID.randomUUID();
+
+        createNamedSubstance(uuid1, "sub1");
+        createNamedSubstance(uuid2, "sub2");
+        addRelationshipAndCreateInverse(applicationEvents, uuid1, uuid2, "foo->bar");
+        updateChangeReason(uuid2, PREVIOUS_CHANGE_REASON);
+
+        removeSourceRelationshipAndRemoveInverse(applicationEvents, uuid1);
+
+        Substance substance2 = substanceEntityService.get(uuid2).get();
+        assertEquals(Collections.emptyList(), substance2.relationships);
+        assertEquals(INVERSE_RELATIONSHIP_DELETION_REASON, substance2.changeReason);
+    }
+
+    @Test
+    public void changingRelationshipTargetShouldSetChangeReasonsOnOldAndNewRelatedSubstances(@Autowired ApplicationEvents applicationEvents) {
+        UUID uuid1 = UUID.randomUUID();
+        UUID uuid2 = UUID.randomUUID();
+        UUID uuid3 = UUID.randomUUID();
+
+        createNamedSubstance(uuid1, "sub1");
+        createNamedSubstance(uuid2, "sub2");
+        createNamedSubstance(uuid3, "sub3");
+        addRelationshipAndCreateInverse(applicationEvents, uuid1, uuid2, "foo->bar");
+        updateChangeReason(uuid2, PREVIOUS_CHANGE_REASON);
+        updateChangeReason(uuid3, PREVIOUS_CHANGE_REASON);
+
+        updateSourceRelationshipAndUpdateInverse(applicationEvents, uuid1, r -> {
+            Substance substance3 = substanceEntityService.get(uuid3).get();
+            r.relatedSubstance = substance3.asSubstanceReference();
+        });
+
+        Substance substance2 = substanceEntityService.get(uuid2).get();
+        assertEquals(Collections.emptyList(), substance2.relationships);
+        assertEquals(INVERSE_RELATIONSHIP_DELETION_REASON, substance2.changeReason);
+
+        Substance substance3 = substanceEntityService.get(uuid3).get();
+        assertEquals(1, substance3.relationships.size());
+        assertEquals("bar->foo", substance3.relationships.get(0).type);
+        assertEquals(uuid1.toString(), substance3.relationships.get(0).relatedSubstance.refuuid);
+        assertEquals(INVERSE_RELATIONSHIP_CHANGE_REASON, substance3.changeReason);
     }
 
     // Are we sure about this test?
@@ -557,6 +644,81 @@ public class RelationshipInvertTest extends AbstractSubstanceJpaEntityTest {
 
         assertEquals(Collections.emptyList(),  substanceEntityService.get(UUID.fromString(uuid)).get().relationships);
         assertEquals(Collections.emptyList(),  substanceEntityService.get(UUID.fromString(uuidA)).get().relationships);
+    }
+
+    private Substance createNamedSubstance(UUID uuid, String name) {
+        new SubstanceBuilder()
+                .addName(name)
+                .setUUID(uuid)
+                .buildJsonAnd(this::assertCreated);
+        return substanceEntityService.get(uuid).get();
+    }
+
+    private void updateChangeReason(UUID uuid, String changeReason) {
+        Substance substance = substanceEntityService.get(uuid).get();
+        SubstanceBuilder.from(substance.toFullJsonNode())
+                .andThenMutate(s -> s.changeReason = changeReason)
+                .buildJsonAnd(this::assertUpdated);
+    }
+
+    private void addRelationshipAndCreateInverse(ApplicationEvents applicationEvents, UUID sourceUuid,
+            UUID relatedUuid, String relationshipType) {
+        applicationEvents.clear();
+
+        Substance source = substanceEntityService.get(sourceUuid).get();
+        Substance related = substanceEntityService.get(relatedUuid).get();
+        SubstanceBuilder.from(source.toFullJsonNode())
+                .addRelationshipTo(related, relationshipType)
+                .buildJsonAnd(this::assertUpdated);
+
+        List<TryToCreateInverseRelationshipEvent> inverseCreateEvents = applicationEvents.stream(TryToCreateInverseRelationshipEvent.class)
+                .collect(Collectors.toList());
+        assertEquals(1, inverseCreateEvents.size());
+        applicationEvents.clear();
+
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.executeWithoutResult(s ->
+                relationshipService.createNewInverseRelationshipFor(inverseCreateEvents.get(0))
+        );
+    }
+
+    private void updateSourceRelationshipAndUpdateInverse(ApplicationEvents applicationEvents, UUID sourceUuid,
+            java.util.function.Consumer<Relationship> relationshipMutator) {
+        applicationEvents.clear();
+
+        Substance source = substanceEntityService.get(sourceUuid).get();
+        SubstanceBuilder.from(source.toFullJsonNode())
+                .andThenMutate(s -> relationshipMutator.accept(s.relationships.get(0)))
+                .buildJsonAnd(this::assertUpdated);
+
+        List<UpdateInverseRelationshipEvent> inverseUpdateEvents = applicationEvents.stream(UpdateInverseRelationshipEvent.class)
+                .collect(Collectors.toList());
+        assertEquals(1, inverseUpdateEvents.size());
+        applicationEvents.clear();
+
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.executeWithoutResult(s ->
+                relationshipService.updateInverseRelationshipFor(inverseUpdateEvents.get(0))
+        );
+    }
+
+    private void removeSourceRelationshipAndRemoveInverse(ApplicationEvents applicationEvents, UUID sourceUuid) {
+        applicationEvents.clear();
+
+        Substance source = substanceEntityService.get(sourceUuid).get();
+        SubstanceBuilder.from(source.toFullJsonNode())
+                .andThenMutate(s -> s.removeRelationshipByUUID(s.relationships.get(0).uuid))
+                .buildJsonAnd(this::assertUpdated);
+
+        List<RemoveInverseRelationshipEvent> inverseRemoveEvents = applicationEvents.stream(RemoveInverseRelationshipEvent.class)
+                .collect(Collectors.toList());
+        assertEquals(1, inverseRemoveEvents.size());
+        applicationEvents.clear();
+
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.executeWithoutResult(s ->
+                relationshipService.removeInverseRelationshipFor(inverseRemoveEvents.get(0))
+        );
     }
 
 }

--- a/gsrs-module-substance-example/src/test/resources/application-test.conf
+++ b/gsrs-module-substance-example/src/test/resources/application-test.conf
@@ -593,3 +593,5 @@ gsrs.importAdapterFactories.substances.list.GSRSJSONImportAdapterFactory =
 		}
 gsrs.substance.structures.saltFilePath=salt_data_public.tsv
 gsrs.security.info.filepath=roles_config.json
+gsrs.substance.relationship.change-reason=Custom configured inverse relationship updated reason
+gsrs.substance.relationship.deletion-reason=Custom configured inverse relationship deleted reason

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/RelationshipService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/RelationshipService.java
@@ -12,6 +12,7 @@ import javax.persistence.PersistenceContext;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -53,8 +54,11 @@ public class RelationshipService {
     @Autowired
     private EntityPersistAdapter entityPersistAdapter;
 
-    private static final String RELATIONSHIP_CHANGE_REASON = "Inverse relationship added/updated";
-    private static final String RELATIONSHIP_DELETION_REASON = "Inverse relationship deleted";
+    @Value("${gsrs.substance.relationship.change-reason:Inverse relationship added/updated}")
+    private String relationshipChangeReason;
+
+    @Value("${gsrs.substance.relationship.deletion-reason:Inverse relationship deleted}")
+    private String relationshipDeletionReason;
 
     private Optional<Relationship> findReverseRelationship(RemoveInverseRelationshipEvent event){
 
@@ -201,7 +205,7 @@ public class RelationshipService {
                 });
                 osub2.removeRelationship(toUpdate);
                 osub2.forceUpdate();
-                osub2.changeReason = RELATIONSHIP_DELETION_REASON;
+                osub2.changeReason = relationshipDeletionReason;
                 Substance osub3=substanceRepository.saveAndFlush(osub2);
                 //trigger new creation event as if this had been a new relationship just
                 //created
@@ -299,7 +303,7 @@ public class RelationshipService {
                 }
             }
             osub2.forceUpdate();
-            osub2.changeReason = RELATIONSHIP_CHANGE_REASON;
+            osub2.changeReason = relationshipChangeReason;
             Substance osub3=RelationshipProcessor.doWithoutEventTracking(()->substanceRepository.saveAndFlush(osub2));
             
             return Optional.of(osub3);
@@ -335,7 +339,7 @@ public class RelationshipService {
                     osub2.removeRelationship(rem);
                 }
                 osub2.forceUpdate();
-                osub2.changeReason = RELATIONSHIP_DELETION_REASON;
+                osub2.changeReason = relationshipDeletionReason;
                 substanceRepository.saveAndFlush(osub2);
                 return Optional.of(osub2);
             });
@@ -414,7 +418,7 @@ public class RelationshipService {
                             // TODO: Are we sure about this? This feels like a hack to make something
                             // behave as it used to in Play, but I think it's brittle. [TP]
                             newSub.updateVersion();
-                            newSub.changeReason = RELATIONSHIP_CHANGE_REASON;
+                            newSub.changeReason = relationshipChangeReason;
                             Substance upSub=newSub;
                             newSub = RelationshipProcessor.doWithoutEventTracking(()->substanceRepository.saveAndFlush(upSub));
                         }

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/RelationshipService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/RelationshipService.java
@@ -53,8 +53,8 @@ public class RelationshipService {
     @Autowired
     private EntityPersistAdapter entityPersistAdapter;
 
-    private static String RELATIONSHIP_CHANGE_REASON ="Inverse relationship added/updated";
-    private static String RELATIONSHIP_DELETION_REASON ="Inverse relationship deleted";
+    private static final String RELATIONSHIP_CHANGE_REASON = "Inverse relationship added/updated";
+    private static final String RELATIONSHIP_DELETION_REASON = "Inverse relationship deleted";
 
     private Optional<Relationship> findReverseRelationship(RemoveInverseRelationshipEvent event){
 
@@ -201,6 +201,7 @@ public class RelationshipService {
                 });
                 osub2.removeRelationship(toUpdate);
                 osub2.forceUpdate();
+                osub2.changeReason = RELATIONSHIP_DELETION_REASON;
                 Substance osub3=substanceRepository.saveAndFlush(osub2);
                 //trigger new creation event as if this had been a new relationship just
                 //created
@@ -298,6 +299,7 @@ public class RelationshipService {
                 }
             }
             osub2.forceUpdate();
+            osub2.changeReason = RELATIONSHIP_CHANGE_REASON;
             Substance osub3=RelationshipProcessor.doWithoutEventTracking(()->substanceRepository.saveAndFlush(osub2));
             
             return Optional.of(osub3);
@@ -335,7 +337,6 @@ public class RelationshipService {
                 osub2.forceUpdate();
                 osub2.changeReason = RELATIONSHIP_DELETION_REASON;
                 substanceRepository.saveAndFlush(osub2);
-                log.info("set change reason for deleted relationship");
                 return Optional.of(osub2);
             });
         }
@@ -413,10 +414,9 @@ public class RelationshipService {
                             // TODO: Are we sure about this? This feels like a hack to make something
                             // behave as it used to in Play, but I think it's brittle. [TP]
                             newSub.updateVersion();
+                            newSub.changeReason = RELATIONSHIP_CHANGE_REASON;
                             Substance upSub=newSub;
-                            upSub.changeReason = RELATIONSHIP_CHANGE_REASON;
                             newSub = RelationshipProcessor.doWithoutEventTracking(()->substanceRepository.saveAndFlush(upSub));
-                            log.info("set changeReason to {} once", RELATIONSHIP_CHANGE_REASON);
                         }
                         return Optional.ofNullable(newSub);
 

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/RelationshipService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/RelationshipService.java
@@ -52,7 +52,10 @@ public class RelationshipService {
 
     @Autowired
     private EntityPersistAdapter entityPersistAdapter;
-    
+
+    private static String RELATIONSHIP_CHANGE_REASON ="Inverse relationship added/updated";
+    private static String RELATIONSHIP_DELETION_REASON ="Inverse relationship deleted";
+
     private Optional<Relationship> findReverseRelationship(RemoveInverseRelationshipEvent event){
 
 
@@ -330,8 +333,9 @@ public class RelationshipService {
                     osub2.removeRelationship(rem);
                 }
                 osub2.forceUpdate();
+                osub2.changeReason = RELATIONSHIP_DELETION_REASON;
                 substanceRepository.saveAndFlush(osub2);
-//									System.out.println("Inverse should be deleted now");
+                log.info("set change reason for deleted relationship");
                 return Optional.of(osub2);
             });
         }
@@ -409,10 +413,10 @@ public class RelationshipService {
                             // TODO: Are we sure about this? This feels like a hack to make something
                             // behave as it used to in Play, but I think it's brittle. [TP]
                             newSub.updateVersion();
-//                            relationshipRepository.save(r);
                             Substance upSub=newSub;
+                            upSub.changeReason = RELATIONSHIP_CHANGE_REASON;
                             newSub = RelationshipProcessor.doWithoutEventTracking(()->substanceRepository.saveAndFlush(upSub));
-                            
+                            log.info("set changeReason to {} once", RELATIONSHIP_CHANGE_REASON);
                         }
                         return Optional.ofNullable(newSub);
 

--- a/gsrs-module-substances-core/src/main/resources/substances-core.conf
+++ b/gsrs-module-substances-core/src/main/resources/substances-core.conf
@@ -1160,3 +1160,5 @@ gsrs.renderers.list=[
 # for molwitch-cdk 1.0.18 and the associated changes in MolwitchLoader in this project:
 gsrs.structure.chemical.molwitch.complexityCutoff=7
 gsrs.structure.chemical.molwitch.maxUndefinedStereoCenters=5
+gsrs.substance.relationship.change-reason=Inverse relationship added/updated/removed by system
+gsrs.substance.relationship.deletion-reason=Inverse relationship added/updated/removed by system


### PR DESCRIPTION
This wording is being used to include situations where a relationship is added, modified or deleted to reflect a change made by the system to the related record.