### PR TITLE
Pubchem name resolver

### DIFF
--- a/gsrs-module-substance-example/src/test/java/example/chem/FeatureGenerationTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/chem/FeatureGenerationTest.java
@@ -25,8 +25,6 @@ public class FeatureGenerationTest {
         GinasChemicalStructure structure = new GinasChemicalStructure();
         structure.molfile = molfileText;
         List<Map<String, String>> properties = FeatureUtils.calculateFeatures( structure.toChemical());
-        //properties.get(0).entrySet().forEach(e-> System.out.printf("key: %s = value: %s\n", e.getKey(), e.getValue()));
-        //Assertions.assertEquals("5", properties.get(0).get("categoryScore"));
         Assertions.assertTrue(properties.isEmpty());
     }
 
@@ -35,9 +33,6 @@ public class FeatureGenerationTest {
         Chemical c1= Chemical.parse("c1ccc2c(c1)c(=O)cc[nH]2");
             List<Map<String, String>> properties = FeatureUtils.calculateFeatures( c1);
         Assertions.assertTrue(properties.isEmpty());
-        /*assertEquals(1, properties.size());
-        assertEquals("A. Secondary Amine" ,properties.get(0).get("type"));
-        assertEquals("0,1", properties.get(0).get("Alpha-Hydrogens"));*/
     }
 
     @Test
@@ -47,8 +42,6 @@ public class FeatureGenerationTest {
         List<Map<String, String>> properties = FeatureUtils.calculateFeatures( c1);
 
         assertEquals(0, properties.size());
-        /*assertEquals("A. Multiple Secondary Amine", properties.get(0).get("type"));
-        assertEquals("0,0", properties.get(0).get("Alpha-Hydrogens"));*/
     }
 
     @Test
@@ -59,9 +52,6 @@ public class FeatureGenerationTest {
         List<Map<String, String>> properties = FeatureUtils.calculateFeatures( c1);
 
         assertEquals(0, properties.size());
-        /*assertEquals("A. Multiple Secondary Amine", properties.get(0).get("type"));
-        assertEquals("2,2", properties.get(0).get("Alpha-Hydrogens"));
-        assertEquals("YES", properties.get(0).get( FeaturizeNitrosamine.FeaturePairRegistry.PIPERAZINE.getFeatureName()));*/
     }
 
     @Test
@@ -69,8 +59,6 @@ public class FeatureGenerationTest {
         Chemical c1= Chemical.parse("O[C@H]([C@@H](O)C(O)=O)C(O)=O.COC1=CC=C(C[C@@H](C)[NH:20]C[C@H](O)C2=CC=C(O)C(NC=O)=C2)C=C1");
         List<Map<String, String>> properties = FeatureUtils.calculateFeatures( c1);
         assertEquals(0, properties.size());
-        /*assertEquals("A. Secondary Amine", properties.get(0).get("type"));
-        assertEquals("NO" ,properties.get(0).get(FeaturizeNitrosamine.FeaturePairRegistry.COOH.getFeatureName()));*/
     }
 
     @Test
@@ -78,8 +66,6 @@ public class FeatureGenerationTest {
         Chemical c1= Chemical.parse("C[C@H]([NH:3]C1=C2N=CNC2=NC=N1)C3=CC4=C(C(Cl)=CC=C4)C(=O)N3C5=CC=CC=C5");
         List<Map<String, String>> properties = FeatureUtils.calculateFeatures( c1);
         assertEquals(0, properties.size());
-        /*assertEquals("A. Secondary Amine", properties.get(0).get("type"));
-        assertEquals("NO", properties.get(0).get(FeaturizeNitrosamine.FeaturePairRegistry.ARYL_ALPHA.getFeatureName()));*/
     }
 
     @Test

--- a/gsrs-module-substance-example/src/test/java/example/resolvers/PubChemNameListResolverTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/resolvers/PubChemNameListResolverTest.java
@@ -19,11 +19,20 @@ public class PubChemNameListResolverTest {
     }
 
     @Test
-    void getNameForSmilesTest() throws IOException, InterruptedException {
-        String smiles = "c1cccc(OC(C)=O)c1C(=O)O";
+    void getNameForInchiKeyTest() throws IOException, InterruptedException {
+        String inChIKey = "BSYNRYMUTXBXSQ-UHFFFAOYSA-N";
         PubChemNameListResolver resolver = new PubChemNameListResolver();
         String expectedName = "2-acetyloxybenzoic acid";
-        String name = resolver.getNamesData(smiles);
+        String name = resolver.getDataForChemical(inChIKey).getIupacName();
         Assertions.assertEquals(expectedName, name);
+    }
+
+    @Test
+    void getCidForInchiKeyTest() throws IOException, InterruptedException {
+        String smiles = "RWWYLEGWBNMMLJ-YSOARWBDSA-N";
+        PubChemNameListResolver resolver = new PubChemNameListResolver();
+        String expectedCid = "121304016";
+        String cid = resolver.getDataForChemical(smiles).getCid();
+        Assertions.assertEquals(expectedCid, cid);
     }
 }

--- a/gsrs-module-substance-example/src/test/java/example/resolvers/PubChemNameListResolverTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/resolvers/PubChemNameListResolverTest.java
@@ -1,0 +1,29 @@
+package example.resolvers;
+
+import ix.ncats.resolvers.PubChemNameListResolver;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class PubChemNameListResolverTest {
+
+    @Test
+    void getIupacNameForCid() throws IOException, InterruptedException {
+        String cid = "3226";
+        PubChemNameListResolver resolver = new PubChemNameListResolver();
+        String iupacName = resolver.getIupacNameForCid(cid);
+        String expectedName = "2-chloro-1-(difluoromethoxy)-1,1,2-trifluoroethane";
+        System.out.printf("received name '%s' for CID %s %n", iupacName, cid);
+        Assertions.assertEquals(expectedName, iupacName);
+    }
+
+    @Test
+    void getNameForSmilesTest() throws IOException, InterruptedException {
+        String smiles = "c1cccc(OC(C)=O)c1C(=O)O";
+        PubChemNameListResolver resolver = new PubChemNameListResolver();
+        String expectedName = "2-acetyloxybenzoic acid";
+        String name = resolver.getNamesData(smiles);
+        Assertions.assertEquals(expectedName, name);
+    }
+}

--- a/gsrs-module-substance-example/src/test/java/example/structureSearch/StructureSearchITTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/structureSearch/StructureSearchITTest.java
@@ -175,22 +175,27 @@ public class StructureSearchITTest extends AbstractSubstanceJpaFullStackEntityTe
     @WithMockUser(value = "admin", roles = "Admin")
     public void ensureSubstructureSearchHasBasicSmartsSupport() throws Exception {
         UUID uuid = UUID.randomUUID();
-        new ChemicalSubstanceBuilder()
-
-                .setStructureWithDefaultReference("COC1=CC=C(O)C2=C(O)C(C)=C3OC(C)(O)C(=O)C3=C12")
-                .addName("Test")
-                .setUUID(uuid)
-                .buildJsonAnd(this::assertCreated);
+        String smiles1 = "COC1=CC=C(O)C2=C(O)C(C)=C3OC(C)(O)C(=O)C3=C12";
 
         UUID uuid2 = UUID.randomUUID();
+        String smiles2 = "CC1=C2OC(C)(O)C(=O)C2=C3C4=C(C=C(O)C3=C1O)N5C=CC=CC5N4";
         new ChemicalSubstanceBuilder()
-
-                .setStructureWithDefaultReference("CC1=C2OC(C)(O)C(=O)C2=C3C4=C(C=C(O)C3=C1O)N5C=CC=CC5=N4")
+                .setStructureWithDefaultReference(smiles2)
                 .addName("Test2")
                 .setUUID(uuid2)
                 .buildJsonAnd(this::assertCreated);
+        System.out.printf("UUID2: %s, SMILES2: %s%n", uuid2, smiles2);
 
-        StructureIndexer.ResultEnumeration result = indexer.substructure("[#7,#8]c1ccc(O)c2c(O)c([#6])c3OC([#6])(O)C(=O)c3c12");
+        new ChemicalSubstanceBuilder()
+                .setStructureWithDefaultReference(smiles1)
+                .addName("Test")
+                .setUUID(uuid)
+                .buildJsonAnd(this::assertCreated);
+        System.out.printf("UUID1: %s, SMILES1: %s%n", uuid, smiles1);
+
+        String oldSmartsForComparison ="[#7,#8]c1ccc(O)c2c(O)c([#6])c3OC([#6])(O)C(=O)c3c12";
+        String smarts = "[#7,#8]C1=CC=C(O)C=2C(O)=C([#6])C3OC([#6])(O)C(=O)C=3C12";
+        StructureIndexer.ResultEnumeration result = indexer.substructure(smarts);
         assertTrue(result.hasMoreElements());
         Set<UUID> matches = new LinkedHashSet<>();
         while(result.hasMoreElements()){

--- a/gsrs-module-substance-example/src/test/java/example/substance/processor/ChemicalNameProcessorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/processor/ChemicalNameProcessorTest.java
@@ -1,0 +1,39 @@
+package example.substance.processor;
+
+import example.GsrsModuleSubstanceApplication;
+import gsrs.module.substance.processors.ChemicalNameProcessor;
+import gsrs.springUtils.AutowireHelper;
+import gsrs.substances.tests.AbstractSubstanceJpaFullStackEntityTest;
+import ix.core.EntityProcessor;
+import ix.ginas.models.v1.Substance;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static example.substance.service.IupacNameServiceTests.createSubstanceWithoutPubchemReference;
+
+@SpringBootTest(classes = GsrsModuleSubstanceApplication.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class ChemicalNameProcessorTest extends AbstractSubstanceJpaFullStackEntityTest {
+
+    @Test
+    void prepersistTest() throws EntityProcessor.FailProcessingException {
+        Substance testSubstance = createSubstanceWithoutPubchemReference();
+        List<String> namesBefore = testSubstance.names.stream()
+                .map(n->n.name)
+                .collect(Collectors.toList());
+        String expectedIupacName = "3-phenylpropylbenzene";
+        ChemicalNameProcessor processor = new ChemicalNameProcessor();
+        AutowireHelper.getInstance().autowire(processor);
+        processor.prePersist(testSubstance);
+        List<String> namesAfter = testSubstance.names.stream()
+                .map(n->n.name)
+                .collect(Collectors.toList());
+        Assertions.assertEquals(namesAfter.size(), namesBefore.size()+1);
+        Assertions.assertTrue(namesAfter.contains(expectedIupacName));
+    }
+}

--- a/gsrs-module-substance-example/src/test/java/example/substance/processor/ChemicalNameProcessorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/processor/ChemicalNameProcessorTest.java
@@ -14,11 +14,11 @@ import org.springframework.test.annotation.DirtiesContext;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static example.substance.service.IupacNameServiceTests.createSubstanceWithoutPubchemReference;
+import static example.testutilities.substanceUtility.createSubstanceWithoutPubchemReference;
 
 @SpringBootTest(classes = GsrsModuleSubstanceApplication.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-public class ChemicalNameProcessorTest extends AbstractSubstanceJpaFullStackEntityTest {
+class ChemicalNameProcessorTest extends AbstractSubstanceJpaFullStackEntityTest {
 
     @Test
     void prepersistTest() throws EntityProcessor.FailProcessingException {

--- a/gsrs-module-substance-example/src/test/java/example/substance/processor/ChemicalNameProcessorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/processor/ChemicalNameProcessorTest.java
@@ -29,7 +29,7 @@ class ChemicalNameProcessorTest extends AbstractSubstanceJpaFullStackEntityTest 
         Substance testSubstance = createSubstanceWithoutPubchemReference();
         List<String> namesBefore = testSubstance.names.stream()
                 .map(n->n.name)
-                .collect(Collectors.toList());
+                .toList();
         String expectedIupacName = "3-phenylpropylbenzene";
 
         ChemicalNameProcessor processor = new ChemicalNameProcessor();
@@ -40,7 +40,7 @@ class ChemicalNameProcessorTest extends AbstractSubstanceJpaFullStackEntityTest 
         processor.prePersist(testSubstance);
         List<String> namesAfter = testSubstance.names.stream()
                 .map(n->n.name)
-                .collect(Collectors.toList());
+                .toList();
         Assertions.assertEquals(namesAfter.size(), namesBefore.size()+1);
         Assertions.assertTrue(namesAfter.contains(expectedIupacName));
     }
@@ -51,7 +51,7 @@ class ChemicalNameProcessorTest extends AbstractSubstanceJpaFullStackEntityTest 
         ((ChemicalSubstance)testSubstance).getStructure().setAccess(Collections.singleton(new Group("protected")));
         List<String> namesBefore = testSubstance.names.stream()
                 .map(n->n.name)
-                .collect(Collectors.toList());
+                .toList();
         String expectedIupacName = "3-phenylpropylbenzene";
 
         ChemicalNameProcessor processor = new ChemicalNameProcessor();
@@ -63,7 +63,7 @@ class ChemicalNameProcessorTest extends AbstractSubstanceJpaFullStackEntityTest 
         processor.prePersist(testSubstance);
         List<String> namesAfter = testSubstance.names.stream()
                 .map(n->n.name)
-                .collect(Collectors.toList());
+                .toList();
         Assertions.assertEquals(namesAfter.size(), namesBefore.size());
         Assertions.assertFalse(namesAfter.contains(expectedIupacName));
     }

--- a/gsrs-module-substance-example/src/test/java/example/substance/processor/ChemicalNameProcessorTest.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/processor/ChemicalNameProcessorTest.java
@@ -5,11 +5,15 @@ import gsrs.module.substance.processors.ChemicalNameProcessor;
 import gsrs.springUtils.AutowireHelper;
 import gsrs.substances.tests.AbstractSubstanceJpaFullStackEntityTest;
 import ix.core.EntityProcessor;
+import ix.ginas.models.v1.ChemicalSubstance;
 import ix.ginas.models.v1.Substance;
+import ix.core.models.Group;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.Collections;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,13 +31,40 @@ class ChemicalNameProcessorTest extends AbstractSubstanceJpaFullStackEntityTest 
                 .map(n->n.name)
                 .collect(Collectors.toList());
         String expectedIupacName = "3-phenylpropylbenzene";
+
         ChemicalNameProcessor processor = new ChemicalNameProcessor();
         AutowireHelper.getInstance().autowire(processor);
+
+        processor.setNameLang("en");
+        processor.setNameType("cn");
         processor.prePersist(testSubstance);
         List<String> namesAfter = testSubstance.names.stream()
                 .map(n->n.name)
                 .collect(Collectors.toList());
         Assertions.assertEquals(namesAfter.size(), namesBefore.size()+1);
         Assertions.assertTrue(namesAfter.contains(expectedIupacName));
+    }
+
+    @Test
+    void prepersistTest2() throws EntityProcessor.FailProcessingException {
+        Substance testSubstance = createSubstanceWithoutPubchemReference();
+        ((ChemicalSubstance)testSubstance).getStructure().setAccess(Collections.singleton(new Group("protected")));
+        List<String> namesBefore = testSubstance.names.stream()
+                .map(n->n.name)
+                .collect(Collectors.toList());
+        String expectedIupacName = "3-phenylpropylbenzene";
+
+        ChemicalNameProcessor processor = new ChemicalNameProcessor();
+        processor.setForbiddenGroups(Collections.singletonList("PROTECTED"));
+        AutowireHelper.getInstance().autowire(processor);
+
+        processor.setNameLang("en");
+        processor.setNameType("cn");
+        processor.prePersist(testSubstance);
+        List<String> namesAfter = testSubstance.names.stream()
+                .map(n->n.name)
+                .collect(Collectors.toList());
+        Assertions.assertEquals(namesAfter.size(), namesBefore.size());
+        Assertions.assertFalse(namesAfter.contains(expectedIupacName));
     }
 }

--- a/gsrs-module-substance-example/src/test/java/example/substance/service/IupacNameServiceTests.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/service/IupacNameServiceTests.java
@@ -45,8 +45,9 @@ public class IupacNameServiceTests {
         return baseSubstance;
     }
     
-    private Substance createSubstanceWithoutPubchemReference() {
+    public static Substance createSubstanceWithoutPubchemReference() {
         ChemicalSubstanceBuilder builder = new ChemicalSubstanceBuilder();
+        builder.addName("dibenzylmethane");
         builder.setStructureWithDefaultReference("c1ccccc1CCCc2ccccc2");
         Reference ref1 = new Reference();
         ref1.docType = "CHEBI";

--- a/gsrs-module-substance-example/src/test/java/example/substance/service/IupacNameServiceTests.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/service/IupacNameServiceTests.java
@@ -1,7 +1,6 @@
 package example.substance.service;
 
 import gsrs.module.substance.services.IupacNameService;
-import ix.ginas.modelBuilders.ChemicalSubstanceBuilder;
 import ix.ginas.models.v1.Reference;
 import ix.ginas.models.v1.Substance;
 import org.junit.jupiter.api.Assertions;
@@ -10,6 +9,9 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static example.testutilities.substanceUtility.createSubstanceWithPubchemReference;
+import static example.testutilities.substanceUtility.createSubstanceWithoutPubchemReference;
 
 public class IupacNameServiceTests {
 
@@ -33,33 +35,5 @@ public class IupacNameServiceTests {
                 .collect(Collectors.toList());
         Reference newRef = service.findOrCreatePubchemReference(substance);
         Assertions.assertTrue(existingReferenceUuids.contains(newRef.uuid));
-    }
-
-    private Substance createSubstanceWithPubchemReference() {
-        Substance baseSubstance = createSubstanceWithoutPubchemReference();
-        Reference ref3 = new Reference();
-        ref3.docType = IupacNameService.PUBCHEM_REFERENCE_TYPE;
-        ref3.citation = "abcd";
-        ref3.uuid = UUID.randomUUID();
-        baseSubstance.addReference(ref3);
-        return baseSubstance;
-    }
-    
-    public static Substance createSubstanceWithoutPubchemReference() {
-        ChemicalSubstanceBuilder builder = new ChemicalSubstanceBuilder();
-        builder.addName("dibenzylmethane");
-        builder.setStructureWithDefaultReference("c1ccccc1CCCc2ccccc2");
-        Reference ref1 = new Reference();
-        ref1.docType = "CHEBI";
-        ref1.citation = "CHEBI:27732";
-        ref1.uuid = UUID.randomUUID();
-        builder.addReference(ref1);
-
-        Reference ref2 = new Reference();
-        ref2.docType = "Data Source";
-        ref2.citation = "23827b";
-        ref2.uuid = UUID.randomUUID();
-        builder.addReference(ref2);
-        return builder.build();
     }
 }

--- a/gsrs-module-substance-example/src/test/java/example/substance/service/IupacNameServiceTests.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/service/IupacNameServiceTests.java
@@ -1,0 +1,65 @@
+package example.substance.service;
+
+import gsrs.module.substance.services.IupacNameService;
+import ix.ginas.modelBuilders.ChemicalSubstanceBuilder;
+import ix.ginas.models.v1.ChemicalSubstance;
+import ix.ginas.models.v1.Reference;
+import ix.ginas.models.v1.Substance;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class IupacNameServiceTests {
+
+    private IupacNameService service = new IupacNameService();
+
+    @Test
+    void testFindOrCreatePubchemReference() {
+        Substance substance = createSubstanceWithoutPubchemReference();
+        List<UUID> existingReferenceUuids = substance.references.stream()
+                .map( r->r.uuid)
+                .collect(Collectors.toList());
+        Reference newRef = service.findOrCreatePubchemReference(substance);
+        Assertions.assertFalse(existingReferenceUuids.contains(newRef.uuid));
+    }
+
+    @Test
+    void testFindOrCreatePubchemReference2() {
+        Substance substance = createSubstanceWithPubchemReference();
+        List<UUID> existingReferenceUuids = substance.references.stream()
+                .map( r->r.uuid)
+                .collect(Collectors.toList());
+        Reference newRef = service.findOrCreatePubchemReference(substance);
+        Assertions.assertTrue(existingReferenceUuids.contains(newRef.uuid));
+    }
+
+    private Substance createSubstanceWithPubchemReference() {
+        Substance baseSubstance = createSubstanceWithoutPubchemReference();
+        Reference ref3 = new Reference();
+        ref3.docType = IupacNameService.PUBCHEM_REFERENCE_TYPE;
+        ref3.citation = "abcd";
+        ref3.uuid = UUID.randomUUID();
+        baseSubstance.addReference(ref3);
+        return baseSubstance;
+    }
+    
+    private Substance createSubstanceWithoutPubchemReference() {
+        ChemicalSubstanceBuilder builder = new ChemicalSubstanceBuilder();
+        builder.setStructureWithDefaultReference("c1ccccc1CCCc2ccccc2");
+        Reference ref1 = new Reference();
+        ref1.docType = "CHEBI";
+        ref1.citation = "CHEBI:27732";
+        ref1.uuid = UUID.randomUUID();
+        builder.addReference(ref1);
+
+        Reference ref2 = new Reference();
+        ref2.docType = "Data Source";
+        ref2.citation = "23827b";
+        ref2.uuid = UUID.randomUUID();
+        builder.addReference(ref2);
+        return builder.build();
+    }
+}

--- a/gsrs-module-substance-example/src/test/java/example/substance/service/IupacNameServiceTests.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/service/IupacNameServiceTests.java
@@ -2,7 +2,6 @@ package example.substance.service;
 
 import gsrs.module.substance.services.IupacNameService;
 import ix.ginas.modelBuilders.ChemicalSubstanceBuilder;
-import ix.ginas.models.v1.ChemicalSubstance;
 import ix.ginas.models.v1.Reference;
 import ix.ginas.models.v1.Substance;
 import org.junit.jupiter.api.Assertions;

--- a/gsrs-module-substance-example/src/test/java/example/substance/service/IupacNameServiceTests.java
+++ b/gsrs-module-substance-example/src/test/java/example/substance/service/IupacNameServiceTests.java
@@ -13,9 +13,9 @@ import java.util.stream.Collectors;
 import static example.testutilities.substanceUtility.createSubstanceWithPubchemReference;
 import static example.testutilities.substanceUtility.createSubstanceWithoutPubchemReference;
 
-public class IupacNameServiceTests {
+class IupacNameServiceTests {
 
-    private IupacNameService service = new IupacNameService();
+    private final IupacNameService service = new IupacNameService();
 
     @Test
     void testFindOrCreatePubchemReference() {

--- a/gsrs-module-substance-example/src/test/java/example/testutilities/substanceUtility.java
+++ b/gsrs-module-substance-example/src/test/java/example/testutilities/substanceUtility.java
@@ -21,7 +21,7 @@ public class substanceUtility {
     public static Substance createSubstanceWithoutPubchemReference() {
         ChemicalSubstanceBuilder builder = new ChemicalSubstanceBuilder();
         builder.addName("dibenzylmethane");
-        builder.setStructureWithDefaultReference("c1ccccc1CCCc2ccccc2");
+        builder.setStructureWithDefaultReference("C1=CC=CC=C1CCCC2=CC=CC=C2");
         Reference ref1 = new Reference();
         ref1.docType = "CHEBI";
         ref1.citation = "CHEBI:27732";

--- a/gsrs-module-substance-example/src/test/java/example/testutilities/substanceUtility.java
+++ b/gsrs-module-substance-example/src/test/java/example/testutilities/substanceUtility.java
@@ -1,0 +1,38 @@
+package example.testutilities;
+
+import gsrs.module.substance.services.IupacNameService;
+import ix.ginas.modelBuilders.ChemicalSubstanceBuilder;
+import ix.ginas.models.v1.Reference;
+import ix.ginas.models.v1.Substance;
+
+import java.util.UUID;
+
+public class substanceUtility {
+    public static Substance createSubstanceWithPubchemReference() {
+        Substance baseSubstance = createSubstanceWithoutPubchemReference();
+        Reference ref3 = new Reference();
+        ref3.docType = IupacNameService.PUBCHEM_REFERENCE_TYPE;
+        ref3.citation = "abcd";
+        ref3.uuid = UUID.randomUUID();
+        baseSubstance.addReference(ref3);
+        return baseSubstance;
+    }
+
+    public static Substance createSubstanceWithoutPubchemReference() {
+        ChemicalSubstanceBuilder builder = new ChemicalSubstanceBuilder();
+        builder.addName("dibenzylmethane");
+        builder.setStructureWithDefaultReference("c1ccccc1CCCc2ccccc2");
+        Reference ref1 = new Reference();
+        ref1.docType = "CHEBI";
+        ref1.citation = "CHEBI:27732";
+        ref1.uuid = UUID.randomUUID();
+        builder.addReference(ref1);
+
+        Reference ref2 = new Reference();
+        ref2.docType = "Data Source";
+        ref2.citation = "23827b";
+        ref2.uuid = UUID.randomUUID();
+        builder.addReference(ref2);
+        return builder.build();
+    }
+}

--- a/gsrs-module-substances-core/pom.xml
+++ b/gsrs-module-substances-core/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>gov.nih.ncats</groupId>
             <artifactId>molwitch-renderer</artifactId>
-            <version>1.0.17</version>
+            <version>1.0.20</version>
         </dependency>
         <dependency>
             <groupId>gov.nih.ncats</groupId>

--- a/gsrs-module-substances-core/pom.xml
+++ b/gsrs-module-substances-core/pom.xml
@@ -52,8 +52,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-            <source>8</source>
-            <target>8</target>
+            <source>11</source>
+            <target>11</target>
         </configuration>
     </plugin>
     </plugins>

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/SubstanceCoreConfiguration.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/SubstanceCoreConfiguration.java
@@ -25,6 +25,7 @@ import ix.core.search.bulk.UserSavedListService;
 import ix.ginas.utils.validation.strategy.GsrsProcessingStrategyFactory;
 import ix.ginas.utils.validation.strategy.GsrsProcessingStrategyFactoryConfiguration;
 import ix.ginas.utils.SubstanceFieldNameDecoratorConfiguration;
+import ix.ncats.resolvers.PubChemNameListResolver;
 import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
@@ -71,7 +72,9 @@ import gsrs.stagingarea.service.ImportMetadataLegacySearchService;
         ChemicalUtils.class,
         SubstanceEntityServiceConfiguration.class,
         UserRoleConfiguration.class,
-        RolesConfig.class
+        RolesConfig.class,
+        IupacNameService.class,
+        PubChemNameListResolver.class
 })
 public class SubstanceCoreConfiguration {
 

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/ChemicalNameProcessor.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/ChemicalNameProcessor.java
@@ -4,8 +4,13 @@ import gsrs.module.substance.services.IupacNameService;
 import ix.core.EntityProcessor;
 import ix.ginas.models.v1.ChemicalSubstance;
 import ix.ginas.models.v1.Substance;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class ChemicalNameProcessor implements EntityProcessor<Substance> {
@@ -13,30 +18,78 @@ public class ChemicalNameProcessor implements EntityProcessor<Substance> {
     @Autowired
     private IupacNameService service;
 
+    @Setter
+    private String nameType = "sys";
+
+    @Setter
+    private String nameLang = "en";
+
+    @Setter
+    private List<String> forbiddenGroups = new ArrayList<>();
+
+    public ChemicalNameProcessor() {
+        this(new HashMap<>());
+    }
+
+    public ChemicalNameProcessor(Map<String, Object> parameters) {
+        if( parameters == null) return;
+
+        if( parameters.containsKey("nameType")) {
+            setNameType((String)parameters.get("nameType"));
+        }
+
+        if( parameters.containsKey("nameLang")) {
+            setNameLang((String)parameters.get("nameLang"));
+        }
+
+        if( parameters.containsKey("forbiddenGroups")) {
+            LinkedHashMap<String, Object> groups = (LinkedHashMap<String, Object>) parameters.get("forbiddenGroups");
+            List<String> groupNames = groups.values().stream()
+                    .filter(Objects::nonNull)
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .map(String::toUpperCase)
+                    .collect(Collectors.toList());
+            setForbiddenGroups(groupNames);
+            log.trace("set forbidden groups to {}", groupNames);
+        }
+    }
+
     @Override
     public void prePersist(Substance obj) throws FailProcessingException {
-        log.trace("IupacNameService prepersist");
+        log.trace("in ChemicalNameProcessor prePersist");
         if(obj instanceof ChemicalSubstance){
-            try {
-                service.ensureIupacName((ChemicalSubstance)obj);
-                log.trace("IupacNameService prepersist called service.ensureIupacName");
+            ChemicalSubstance chem = (ChemicalSubstance) obj;
+            if(chem.getStructure().getAccess() != null &&
+                    chem.getStructure().getAccess().stream().map(g->g.name.toUpperCase()).anyMatch(g2->this.forbiddenGroups.contains(g2))){
+                log.info("structure access contains a forbidden group");
+                return;
             }
-            catch (Exception ex){
-                log.error("Error looking up PubChem name for {}", obj.getOrGenerateUUID());
-                ex.printStackTrace();
+            try {
+                service.ensureIupacName((ChemicalSubstance)obj, nameType, nameLang);
+            }
+            catch (IOException | InterruptedException  ex){
+                log.error("Error looking up PubChem name for {}", obj.getOrGenerateUUID(), ex);
+                Thread.currentThread().interrupt(); // if InterruptedException is possible
             }
         }
     }
 
     @Override
     public void preUpdate(Substance obj) throws FailProcessingException {
-        log.trace("IupacNameService preUpdate called");
+        log.trace("in ChemicalNameProcessor preUpdate");
         if(obj instanceof ChemicalSubstance){
-            try {
-                service.ensureIupacName((ChemicalSubstance)obj);
+            ChemicalSubstance chem = (ChemicalSubstance)obj;
+            if(chem.getStructure().getAccess().stream().map(g->g.name.toUpperCase()).anyMatch(g2->this.forbiddenGroups.contains(g2))){
+                log.info("structure access contains a forbidden group");
+                return;
             }
-            catch (Exception ex){
-                log.error("Error looking up PubChem name for {}", obj.getOrGenerateUUID());
+            try {
+                service.ensureIupacName((ChemicalSubstance)obj, nameType, nameLang);
+            }
+            catch (IOException | InterruptedException  ex){
+                log.error("Error looking up PubChem name for {}", obj.getOrGenerateUUID(), ex);
+                Thread.currentThread().interrupt(); // if InterruptedException is possible
             }
         }
     }
@@ -45,5 +98,4 @@ public class ChemicalNameProcessor implements EntityProcessor<Substance> {
     public Class<Substance> getEntityClass() {
         return Substance.class;
     }
-
 }

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/ChemicalNameProcessor.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/ChemicalNameProcessor.java
@@ -5,17 +5,21 @@ import ix.core.EntityProcessor;
 import ix.ginas.models.v1.ChemicalSubstance;
 import ix.ginas.models.v1.Substance;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Slf4j
 public class ChemicalNameProcessor implements EntityProcessor<Substance> {
 
-    private IupacNameService service = new IupacNameService();
+    @Autowired
+    private IupacNameService service;
 
     @Override
     public void prePersist(Substance obj) throws FailProcessingException {
+        log.trace("IupacNameService prepersist");
         if(obj instanceof ChemicalSubstance){
             try {
-                service.ensureIupacName  ((ChemicalSubstance)obj);
+                service.ensureIupacName((ChemicalSubstance)obj);
+                log.trace("IupacNameService prepersist called service.ensureIupacName");
             }
             catch (Exception ex){
                 log.error("Error looking up PubChem name for {}", obj.getOrGenerateUUID());
@@ -25,9 +29,10 @@ public class ChemicalNameProcessor implements EntityProcessor<Substance> {
 
     @Override
     public void preUpdate(Substance obj) throws FailProcessingException {
+        log.trace("IupacNameService preUpdate called");
         if(obj instanceof ChemicalSubstance){
             try {
-                service.ensureIupacName  ((ChemicalSubstance)obj);
+                service.ensureIupacName((ChemicalSubstance)obj);
             }
             catch (Exception ex){
                 log.error("Error looking up PubChem name for {}", obj.getOrGenerateUUID());

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/ChemicalNameProcessor.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/ChemicalNameProcessor.java
@@ -23,6 +23,7 @@ public class ChemicalNameProcessor implements EntityProcessor<Substance> {
             }
             catch (Exception ex){
                 log.error("Error looking up PubChem name for {}", obj.getOrGenerateUUID());
+                ex.printStackTrace();
             }
         }
     }

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/ChemicalNameProcessor.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/processors/ChemicalNameProcessor.java
@@ -1,0 +1,43 @@
+package gsrs.module.substance.processors;
+
+import gsrs.module.substance.services.IupacNameService;
+import ix.core.EntityProcessor;
+import ix.ginas.models.v1.ChemicalSubstance;
+import ix.ginas.models.v1.Substance;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ChemicalNameProcessor implements EntityProcessor<Substance> {
+
+    private IupacNameService service = new IupacNameService();
+
+    @Override
+    public void prePersist(Substance obj) throws FailProcessingException {
+        if(obj instanceof ChemicalSubstance){
+            try {
+                service.ensureIupacName  ((ChemicalSubstance)obj);
+            }
+            catch (Exception ex){
+                log.error("Error looking up PubChem name for {}", obj.getOrGenerateUUID());
+            }
+        }
+    }
+
+    @Override
+    public void preUpdate(Substance obj) throws FailProcessingException {
+        if(obj instanceof ChemicalSubstance){
+            try {
+                service.ensureIupacName  ((ChemicalSubstance)obj);
+            }
+            catch (Exception ex){
+                log.error("Error looking up PubChem name for {}", obj.getOrGenerateUUID());
+            }
+        }
+    }
+
+    @Override
+    public Class<Substance> getEntityClass() {
+        return Substance.class;
+    }
+
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
@@ -6,17 +6,24 @@ import ix.ginas.models.v1.Reference;
 import ix.ginas.models.v1.Substance;
 import ix.ncats.resolvers.PubChemNameListResolver;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
 
 @Slf4j
 public class IupacNameService {
-    private PubChemNameListResolver resolver = new PubChemNameListResolver();
+    @Autowired
+    private PubChemNameListResolver resolver;
 
     public final static String PUBCHEM_REFERENCE_TYPE = "PUBCHEM";
+    private final static String IUPAC_NAME_LANGUAGE = "en";
 
     public boolean ensureIupacName(ChemicalSubstance substance) throws IOException, InterruptedException {
         String iupacName = resolver.getNamesData(substance.getStructure().smiles);
+        if(iupacName == null || iupacName.length() ==0) {
+            log.info("no IUPAC name found for this substance");
+            return false;
+        }
         boolean foundName = substance.names.stream()
                 .anyMatch(n->n.name.equalsIgnoreCase(iupacName));
         if( foundName ) {
@@ -26,7 +33,11 @@ public class IupacNameService {
         Name iupacNameObject = new Name();
         iupacNameObject.name = iupacName;
         iupacNameObject.type = "sys";
-        iupacNameObject.addReference(findOrCreatePubchemReference(substance));
+        iupacNameObject.addLanguage(IUPAC_NAME_LANGUAGE);
+        iupacNameObject.assignOwner(substance);
+        Reference newReference = findOrCreatePubchemReference(substance);
+        iupacNameObject.addReference(newReference);
+        substance.references.add(newReference);
         substance.names.add(iupacNameObject);
         return true;
     }

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
@@ -1,14 +1,13 @@
 package gsrs.module.substance.services;
 
-import ix.ginas.models.v1.ChemicalSubstance;
-import ix.ginas.models.v1.Name;
-import ix.ginas.models.v1.Reference;
-import ix.ginas.models.v1.Substance;
+import ix.core.models.PubChemResolutionResult;
+import ix.ginas.models.v1.*;
 import ix.ncats.resolvers.PubChemNameListResolver;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
+import java.util.List;
 
 @Slf4j
 public class IupacNameService {
@@ -17,10 +16,22 @@ public class IupacNameService {
 
     public final static String PUBCHEM_REFERENCE_TYPE = "PUBCHEM";
     private final static String IUPAC_NAME_LANGUAGE = "en";
+    private final static String PUBCHEM_CODE_SYSTEM = "PUBCHEM";
+    private final static String PUBCHEM_CODE_TYPE = "PRIMARY";
 
     public boolean ensureIupacName(ChemicalSubstance substance, String nameType, String nameLanguage)
             throws IOException, InterruptedException {
-        String iupacName = resolver.getNamesData(substance.getStructure().smiles);
+        List<String> inchiKeys = substance.getStructure().getInChIKeysAndThrow();
+        if( inchiKeys== null || inchiKeys.size()==0) {
+            log.warn("No InChIKey found for input");
+            return false;
+        }
+        if(inchiKeys.size() >= 2) {
+            log.warn("More than one InChIKey found for input");
+            return false;
+        }
+        PubChemResolutionResult result= resolver.getDataForChemical(inchiKeys.get(0));
+        String iupacName = result.getIupacName();
         if(iupacName == null || iupacName.length() ==0) {
             log.info("no IUPAC name found for this substance");
             return false;
@@ -41,6 +52,19 @@ public class IupacNameService {
         substance.references.add(newReference);
         newReference.setOwner(substance);
         substance.names.add(iupacNameObject);
+        boolean foundCode = substance.codes.stream()
+                .anyMatch(c->c.code.equalsIgnoreCase(result.getCid()) && c.codeSystem.equalsIgnoreCase("pubchem"));
+        if(!foundCode) {
+            Code cidCode = new Code();
+            cidCode.codeSystem= PUBCHEM_CODE_SYSTEM;
+            cidCode.code = result.getCid();
+            cidCode.type=PUBCHEM_CODE_TYPE;
+            cidCode.setOwner(substance);
+            substance.codes.add(cidCode);
+        } else {
+            log.info("Substance already has a PUBCHEM code");
+        }
+
         return true;
     }
 

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
@@ -18,6 +18,7 @@ public class IupacNameService {
     private final static String IUPAC_NAME_LANGUAGE = "en";
     private final static String PUBCHEM_CODE_SYSTEM = "PUBCHEM";
     private final static String PUBCHEM_CODE_TYPE = "PRIMARY";
+    private final static String PUBCHEM_CODE_URL_STEM = "https://pubchem.ncbi.nlm.nih.gov/compound/";
 
     public boolean ensureIupacName(ChemicalSubstance substance, String nameType, String nameLanguage)
             throws IOException, InterruptedException {
@@ -31,6 +32,10 @@ public class IupacNameService {
             return false;
         }
         PubChemResolutionResult result= resolver.getDataForChemical(inchiKeys.get(0));
+        if(result==null) {
+            log.info("No PubChem info found for substances");
+            return false;
+        }
         String iupacName = result.getIupacName();
         if(iupacName == null || iupacName.length() ==0) {
             log.info("no IUPAC name found for this substance");
@@ -53,12 +58,13 @@ public class IupacNameService {
         newReference.setOwner(substance);
         substance.names.add(iupacNameObject);
         boolean foundCode = substance.codes.stream()
-                .anyMatch(c->c.code.equalsIgnoreCase(result.getCid()) && c.codeSystem.equalsIgnoreCase("pubchem"));
+                .anyMatch(c->c.code.equalsIgnoreCase(result.getCid()) && c.codeSystem.equalsIgnoreCase(PUBCHEM_CODE_SYSTEM));
         if(!foundCode) {
             Code cidCode = new Code();
             cidCode.codeSystem= PUBCHEM_CODE_SYSTEM;
             cidCode.code = result.getCid();
             cidCode.type=PUBCHEM_CODE_TYPE;
+            cidCode.url = PUBCHEM_CODE_URL_STEM + result.getCid();
             cidCode.setOwner(substance);
             substance.codes.add(cidCode);
         } else {

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
@@ -52,6 +52,7 @@ public class IupacNameService {
             pubchemReference = new Reference();
             pubchemReference.docType = PUBCHEM_REFERENCE_TYPE;
             pubchemReference.citation = PUBCHEM_REFERENCE_TYPE;
+            pubchemReference.publicDomain = true;
         }
         return pubchemReference;
     }

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
@@ -1,0 +1,45 @@
+package gsrs.module.substance.services;
+
+import ix.ginas.models.v1.ChemicalSubstance;
+import ix.ginas.models.v1.Name;
+import ix.ginas.models.v1.Reference;
+import ix.ginas.models.v1.Substance;
+import ix.ncats.resolvers.PubChemNameListResolver;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+public class IupacNameService {
+    private PubChemNameListResolver resolver = new PubChemNameListResolver();
+
+    public final static String PUBCHEM_REFERENCE_TYPE = "PUBCHEM";
+
+    public boolean ensureIupacName(ChemicalSubstance substance) throws IOException, InterruptedException {
+        String iupacName = resolver.getNamesData(substance.getStructure().smiles);
+        boolean foundName = substance.names.stream()
+                .anyMatch(n->n.name.equalsIgnoreCase(iupacName));
+        if( foundName ) {
+            log.info("substance already had IUPAC name {}", iupacName);
+            return false;
+        }
+        Name iupacNameObject = new Name();
+        iupacNameObject.name = iupacName;
+        iupacNameObject.type = "sys";
+        iupacNameObject.addReference(findOrCreatePubchemReference(substance));
+        substance.names.add(iupacNameObject);
+        return true;
+    }
+
+    public Reference findOrCreatePubchemReference(Substance substance) {
+        Reference pubchemReference= substance.references.stream()
+                .filter(r->r.docType.equalsIgnoreCase(PUBCHEM_REFERENCE_TYPE))
+                .findFirst().orElse(null);
+        if( pubchemReference ==null) {
+            pubchemReference = new Reference();
+            pubchemReference.docType = PUBCHEM_REFERENCE_TYPE;
+            pubchemReference.citation = PUBCHEM_REFERENCE_TYPE;
+        }
+        return pubchemReference;
+    }
+}

--- a/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
+++ b/gsrs-module-substances-core/src/main/java/gsrs/module/substance/services/IupacNameService.java
@@ -18,7 +18,8 @@ public class IupacNameService {
     public final static String PUBCHEM_REFERENCE_TYPE = "PUBCHEM";
     private final static String IUPAC_NAME_LANGUAGE = "en";
 
-    public boolean ensureIupacName(ChemicalSubstance substance) throws IOException, InterruptedException {
+    public boolean ensureIupacName(ChemicalSubstance substance, String nameType, String nameLanguage)
+            throws IOException, InterruptedException {
         String iupacName = resolver.getNamesData(substance.getStructure().smiles);
         if(iupacName == null || iupacName.length() ==0) {
             log.info("no IUPAC name found for this substance");
@@ -32,12 +33,13 @@ public class IupacNameService {
         }
         Name iupacNameObject = new Name();
         iupacNameObject.name = iupacName;
-        iupacNameObject.type = "sys";
-        iupacNameObject.addLanguage(IUPAC_NAME_LANGUAGE);
+        iupacNameObject.type = nameType;
+        iupacNameObject.addLanguage(nameLanguage);
         iupacNameObject.assignOwner(substance);
         Reference newReference = findOrCreatePubchemReference(substance);
         iupacNameObject.addReference(newReference);
         substance.references.add(newReference);
+        newReference.setOwner(substance);
         substance.names.add(iupacNameObject);
         return true;
     }

--- a/gsrs-module-substances-core/src/main/java/ix/core/models/PubChemResolutionResult.java
+++ b/gsrs-module-substances-core/src/main/java/ix/core/models/PubChemResolutionResult.java
@@ -1,0 +1,16 @@
+package ix.core.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PubChemResolutionResult {
+    private String iupacName;
+    private String cid;
+    private String lookupValue;
+}

--- a/gsrs-module-substances-core/src/main/java/ix/core/models/Structure.java
+++ b/gsrs-module-substances-core/src/main/java/ix/core/models/Structure.java
@@ -474,11 +474,6 @@ public class Structure extends BaseModel {
         log.trace("in getInChIKeysAndThrow(), stereoChemistry: {}, opticalActivity: {}", this.stereoChemistry, this.opticalActivity);
         try {
 
-//        if( this.stereoChemistry == null || !(this.stereoChemistry.toString().equalsIgnoreCase(Stereo.EPIMERIC.toString())
-//            || this.stereoChemistry.toString().equalsIgnoreCase(Stereo.RACEMIC.toString() ))) {
-//            //handle non-epimers
-//            return Collections.singletonList(getInChIKey());
-//        }
             if( this.opticalActivity != Optical.PLUS_MINUS || this.definedStereo.intValue() == 0) {
                 return Collections.singletonList(getInChIKey());
             }

--- a/gsrs-module-substances-core/src/main/java/ix/ncats/resolvers/PubChemNameListResolver.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ncats/resolvers/PubChemNameListResolver.java
@@ -17,13 +17,7 @@ import java.util.List;
 
 @Slf4j
 public class PubChemNameListResolver implements Resolver<List<String>> {
-    public static final String PUBCHEM_RESOLVER =
-            "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name";
-    public static final String PUBCHEM_RESOLVER_SID =
-            "https://pubchem.ncbi.nlm.nih.gov/rest/pug/substance/name";
-
     private static final  String PUG      = "https://pubchem.ncbi.nlm.nih.gov/rest/pug";
-    private static final String PUG_VIEW = "https://pubchem.ncbi.nlm.nih.gov/rest/pug_view";
 
     @Override
     public Class<List<String>> getType() {
@@ -38,7 +32,6 @@ public class PubChemNameListResolver implements Resolver<List<String>> {
     @Override
     public List<String> resolve(String name) {
         //this name is really SMILES
-
         return List.of();
     }
 
@@ -72,17 +65,16 @@ public class PubChemNameListResolver implements Resolver<List<String>> {
                     cids.add(cidNode.asText());
                 }
             }
-            if(cids== null ){
-                log.warn("No CID found for SMILES {}", smiles);
-            } else if(cids.size()==1) {
-                System.out.printf("cid: %s%n", cids.get(0));
-                return getIupacNameForCid(cids.get(0));
+            if(cids.size()==1) {
+                log.trace("cid: {}}", cids.get(0));
+                if( cids.get(0) != "0") {
+                    return getIupacNameForCid(cids.get(0));
+                }
             }
-            log.warn("search for {} returned nothing", smiles);
+            log.warn("search for {} returned nothing useful", smiles);
         }
         else {
             log.info("Error looking up {}: {}", smiles, response.body());
-            System.out.printf("Error looking up %s: %s%n", smiles, response.body());
         }
         return null;
     }

--- a/gsrs-module-substances-core/src/main/java/ix/ncats/resolvers/PubChemNameListResolver.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ncats/resolvers/PubChemNameListResolver.java
@@ -1,0 +1,118 @@
+package ix.ncats.resolvers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class PubChemNameListResolver implements Resolver<List<String>> {
+    public static final String PUBCHEM_RESOLVER =
+            "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name";
+    public static final String PUBCHEM_RESOLVER_SID =
+            "https://pubchem.ncbi.nlm.nih.gov/rest/pug/substance/name";
+
+    private static final  String PUG      = "https://pubchem.ncbi.nlm.nih.gov/rest/pug";
+    private static final String PUG_VIEW = "https://pubchem.ncbi.nlm.nih.gov/rest/pug_view";
+
+    @Override
+    public Class<List<String>> getType() {
+        return (Class<List<String>>) (Class<?>) List.class;
+    }
+
+    @Override
+    public String getName() {
+        return this.getClass().getName();
+    }
+
+    @Override
+    public List<String> resolve(String name) {
+        //this name is really SMILES
+
+        return List.of();
+    }
+
+    public String getNamesData(String smiles) throws IOException, InterruptedException {
+
+        String url = String.format("%s/compound/smiles/cids/JSON", PUG);
+        String smilesForm = "smiles=" + URLEncoder.encode(smiles, StandardCharsets.UTF_8);
+        String contentTypeForPubChem = "application/x-www-form-urlencoded";
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(30))
+                .header("Content-Type", contentTypeForPubChem)
+                .POST(HttpRequest.BodyPublishers.ofString(smilesForm))
+                .build();
+
+        HttpResponse<String> response =
+                client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        int status = response.statusCode();
+        if( status>= 200 && status < 300) {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode o= mapper.readTree(response.body());
+            JsonNode cidsNode =o.path("IdentifierList").path("CID");
+            List<String> cids = new ArrayList<>();
+            if (cidsNode.isArray()) {
+                for (JsonNode cidNode : cidsNode) {
+                    cids.add(cidNode.asText());
+                }
+            }
+            if(cids== null ){
+                log.warn("No CID found for SMILES {}", smiles);
+            } else if(cids.size()==1) {
+                System.out.printf("cid: %s%n", cids.get(0));
+                return getIupacNameForCid(cids.get(0));
+            }
+            log.warn("search for {} returned nothing", smiles);
+        }
+        else {
+            log.info("Error looking up {}: {}", smiles, response.body());
+            System.out.printf("Error looking up %s: %s%n", smiles, response.body());
+        }
+        return null;
+    }
+
+    public String getIupacNameForCid(String cid)  throws IOException, InterruptedException {
+        ObjectMapper mapper = new ObjectMapper();
+        String url = String.format("%s/compound/cid/%s/property/IUPACName,InChIKey/JSON", PUG, cid);
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(30))
+                .GET()
+                .build();
+
+        HttpResponse<String> response =
+                client.send(request, HttpResponse.BodyHandlers.ofString());
+        if( response.statusCode() >= 200 && response.statusCode()< 300) {
+            JsonNode dataNode = mapper.readTree(response.body());
+            JsonNode nameNode =dataNode.findPath("IUPACName");
+            if(nameNode!= null) {
+                return  nameNode.asText();
+            }
+            return response.body();
+        } else {
+            log.warn("Error looking up CID {}; {}", cid, response.body());
+        }
+        return null;
+    }
+
+}

--- a/gsrs-module-substances-core/src/main/java/ix/ncats/resolvers/PubChemNameListResolver.java
+++ b/gsrs-module-substances-core/src/main/java/ix/ncats/resolvers/PubChemNameListResolver.java
@@ -2,6 +2,7 @@ package ix.ncats.resolvers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import ix.core.models.PubChemResolutionResult;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -14,6 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.StreamSupport;
 
 @Slf4j
 public class PubChemNameListResolver implements Resolver<List<String>> {
@@ -35,10 +37,11 @@ public class PubChemNameListResolver implements Resolver<List<String>> {
         return List.of();
     }
 
-    public String getNamesData(String smiles) throws IOException, InterruptedException {
+    public PubChemResolutionResult getDataForChemical(String inchikey) throws IOException, InterruptedException {
 
-        String url = String.format("%s/compound/smiles/cids/JSON", PUG);
-        String smilesForm = "smiles=" + URLEncoder.encode(smiles, StandardCharsets.UTF_8);
+        PubChemResolutionResult result = new PubChemResolutionResult();
+        String url = String.format("%s/compound/inchikey/cids/JSON", PUG);
+        String smilesForm = "inchikey=" + URLEncoder.encode(inchikey, StandardCharsets.UTF_8);
         String contentTypeForPubChem = "application/x-www-form-urlencoded";
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
@@ -57,24 +60,26 @@ public class PubChemNameListResolver implements Resolver<List<String>> {
         int status = response.statusCode();
         if( status>= 200 && status < 300) {
             ObjectMapper mapper = new ObjectMapper();
-            JsonNode o= mapper.readTree(response.body());
-            JsonNode cidsNode =o.path("IdentifierList").path("CID");
-            List<String> cids = new ArrayList<>();
-            if (cidsNode.isArray()) {
-                for (JsonNode cidNode : cidsNode) {
-                    cids.add(cidNode.asText());
-                }
-            }
+            JsonNode cidsNode = mapper.readTree(response.body())
+                    .path("IdentifierList")
+                    .path("CID");
+
+            List<String> cids = StreamSupport.stream(cidsNode.spliterator(), false)
+                    .map(JsonNode::asText)
+                    .toList();
+
             if(cids.size()==1) {
                 log.trace("cid: {}}", cids.get(0));
+                result.setCid(cids.get(0));
                 if( cids.get(0) != "0") {
-                    return getIupacNameForCid(cids.get(0));
+                    result.setIupacName(getIupacNameForCid(cids.get(0)));
+                    return result;
                 }
             }
-            log.warn("search for {} returned nothing useful", smiles);
+            log.warn("search for {} returned nothing useful", inchikey);
         }
         else {
-            log.info("Error looking up {}: {}", smiles, response.body());
+            log.info("Error looking up {}: {}", inchikey, response.body());
         }
         return null;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
                     <plugin>
                         <groupId>org.projectlombok</groupId>
                         <artifactId>lombok-maven-plugin</artifactId>
-                        <version>1.18.20.0</version>
+                        <version>1.18.22.0</version>
                         <executions>
                             <execution>
                                 <phase>generate-sources</phase>
@@ -164,6 +164,7 @@
                                     <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
                                     <outputDirectory>${project.build.directory}/generated-sources/delombok</outputDirectory>
                                     <addOutputDirectory>false</addOutputDirectory>
+									<encoding>UTF-8</encoding>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
This PR adds an entity processor that checks each new or updated chemical substance:
* Does the definition have protection that makes it non-public?  If so, skip further processing.
* (This processing is configurable)
* Use the SMILES to query PubChem.  
* If there is a match, retrieve the IUPAC name from PubChem and create a new name, with a new reference.
